### PR TITLE
Implement Obsidian Tags support

### DIFF
--- a/Nodsoft.MoltenObsidian/Converter/ObsidianPipelineBuilder.cs
+++ b/Nodsoft.MoltenObsidian/Converter/ObsidianPipelineBuilder.cs
@@ -18,6 +18,7 @@ public sealed class ObsidianPipelineBuilder : MarkdownPipelineBuilder
 		// Configure the pipeline for all features. This should enable 90% of all Obsidian MD features.
 		this.UseAdvancedExtensions()
 			.UseInternalLinks()
+			.UseObsidianTags()
 			.UseSyntaxHighlighting(darkTheme ? StyleDictionary.DefaultDark : StyleDictionary.DefaultLight);
 
 		// Configure the pipeline for Bootstrap support, if requested.

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/ObsidianInternalLinksExtension.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/ObsidianInternalLinksExtension.cs
@@ -8,7 +8,7 @@ using Nodsoft.MoltenObsidian.Vault;
 namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.InternalLinks;
 
 /// <summary>
-/// Provides an extension doe the Markdig parser to support Obsidian internal links.
+/// Provides an extension for the Markdig parser to support Obsidian internal links.
 /// </summary>
 public sealed class InternalLinksExtension : IMarkdownExtension
 {

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/MarkdownExtensions.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/MarkdownExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Markdig;
 using Nodsoft.MoltenObsidian.Infrastructure.Markdown.InternalLinks;
+using Nodsoft.MoltenObsidian.Infrastructure.Markdown.Tags;
 using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown;
@@ -20,6 +21,18 @@ public static class MarkdownExtensions
 	public static MarkdownPipelineBuilder UseInternalLinks(this MarkdownPipelineBuilder builder)
 	{
 		builder.Extensions.AddIfNotAlready<InternalLinksExtension>();
+		return builder;
+	}
+	
+	/// <summary>
+	/// Enables support for Obsidian tags.
+	/// </summary>
+	/// <param name="builder">The <see cref="MarkdownPipelineBuilder"/> to enable the extension on.</param>
+	/// <returns>The <see cref="MarkdownPipelineBuilder"/> with the extension enabled.</returns>
+	/// <seealso cref="ObsidianTagsExtension"/>
+	public static MarkdownPipelineBuilder UseObsidianTags(this MarkdownPipelineBuilder builder)
+	{
+		builder.Extensions.AddIfNotAlready<ObsidianTagsExtension>();
 		return builder;
 	}
 }

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsExtension.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsExtension.cs
@@ -1,0 +1,28 @@
+using Markdig;
+using Markdig.Renderers;
+
+namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.Tags;
+
+/// <summary>
+/// Provides an extension for the Markdig parser to support Obsidian tags.
+/// </summary>
+public class ObsidianTagsExtension : IMarkdownExtension
+{
+    /// <inheritdoc />
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        if (!pipeline.InlineParsers.Contains<ObsidianTagsParser>())
+        {
+            pipeline.InlineParsers.Add(new ObsidianTagsParser());
+        }
+    }
+
+    /// <inheritdoc />
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+        if (renderer is HtmlRenderer htmlRenderer)
+        {
+            htmlRenderer.ObjectRenderers.AddIfNotAlready(new ObsidianTagsRenderer());
+        }
+    }
+}

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsParser.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsParser.cs
@@ -9,16 +9,15 @@ namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.Tags;
 /// </summary>
 public class ObsidianTagsParser : InlineParser
 {
-    private static readonly Regex _tagRegex = new(
-        @"\#(?<tag>[a-zA-Z_/-][\w_/-]*)",
-        RegexOptions.Compiled
-        | RegexOptions.IgnorePatternWhitespace
-        | RegexOptions.ExplicitCapture
-#if NET8_0_OR_GREATER
-        | RegexOptions.NonBacktracking
-#endif
-        
-    );
+//     private static readonly Regex _tagRegex = new(
+//         @"\#(?<tag>[a-zA-Z_/-][\w_/-]*)",
+//         RegexOptions.Compiled
+//         | RegexOptions.IgnorePatternWhitespace
+//         | RegexOptions.ExplicitCapture
+// #if NET8_0_OR_GREATER
+//         | RegexOptions.NonBacktracking
+// #endif
+//     );
     
     /// <summary>
     /// Initializes a new instance of the <see cref="ObsidianTagsParser"/> class.
@@ -32,26 +31,33 @@ public class ObsidianTagsParser : InlineParser
     public override bool Match(InlineProcessor processor, ref StringSlice slice)
     {
         // Seek to the first hash character
-        if (slice.CurrentChar is not '#')
+        if (slice.CurrentChar is not '#' || !slice.PeekChar(-1).IsWhiteSpaceOrZero() || slice.PeekChar() is '#')
         {
             return false;
         }
 
         // Grab the remainder of the slice, and check if it matches the tag pattern.
-        Match match = _tagRegex.Match(slice.Text[slice.Start..slice.End]);
+        
+        // Set the end position to the next blank space, forbidden character, or end of the slice.
+        // Allowed chars: a-z, A-Z, 0-9, _, /, -
+        int endPos = slice.Start;
+        while (endPos < slice.Text.Length && !slice[endPos].IsWhiteSpaceOrZero())
+        {
+            endPos++;
+        }
 
-        if (!match.Success)
+        if (slice.Text[slice.Start..endPos] is not ['#', .. [_, ..] match])
         {
             return false;
         }
-
+        
         // Create a new tag inline, and add it to the processor.
-        processor.Inline = new Tag(match.Groups["tag"].Value)
+        processor.Inline = new Tag(match)
         {
-            Span = { Start = slice.Start, End = slice.Start + match.Length }
+            Span = { Start = slice.Start, End = endPos }
         };
 
-        slice.Start += match.Length;
+        slice.Start = endPos + 1;
         return true;
     }
 }

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsParser.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsParser.cs
@@ -1,0 +1,57 @@
+using System.Text.RegularExpressions;
+using Markdig.Helpers;
+using Markdig.Parsers;
+
+namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.Tags;
+
+/// <summary>
+/// Provides parsing for Obsidian Tags for Markdig.
+/// </summary>
+public class ObsidianTagsParser : InlineParser
+{
+    private static readonly Regex _tagRegex = new(
+        @"\#(?<tag>[a-zA-Z_/-][\w_/-]*)",
+        RegexOptions.Compiled
+        | RegexOptions.IgnorePatternWhitespace
+        | RegexOptions.ExplicitCapture
+#if NET8_0_OR_GREATER
+        | RegexOptions.NonBacktracking
+#endif
+        
+    );
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObsidianTagsParser"/> class.
+    /// </summary>
+    public ObsidianTagsParser()
+    {
+        OpeningCharacters = ['#'];
+    }
+
+    /// <inheritdoc />
+    public override bool Match(InlineProcessor processor, ref StringSlice slice)
+    {
+        // Seek to the first hash character
+        if (slice.CurrentChar is not '#')
+        {
+            return false;
+        }
+
+        // Grab the remainder of the slice, and check if it matches the tag pattern.
+        Match match = _tagRegex.Match(slice.Text[slice.Start..slice.End]);
+
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        // Create a new tag inline, and add it to the processor.
+        processor.Inline = new Tag(match.Groups["tag"].Value)
+        {
+            Span = { Start = slice.Start, End = slice.Start + match.Length }
+        };
+
+        slice.Start += match.Length;
+        return true;
+    }
+}

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsRenderer.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsRenderer.cs
@@ -16,7 +16,7 @@ public class ObsidianTagsRenderer : HtmlObjectRenderer<Tag>
             return;
         }
 
-        renderer.Write(/*lang=html*/"<span class=\"tag\">");
+        renderer.Write(/*lang=html*/$"<span class=\"tag moltenobsidian-tag\" data-name=\"{obj.Name.ToLower()}\">");
         renderer.Write(obj.Name);
         renderer.WriteAttributes(obj);
         renderer.Write(/*lang=html*/"</span>");

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsRenderer.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/ObsidianTagsRenderer.cs
@@ -1,0 +1,24 @@
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+
+namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.Tags;
+
+/// <summary>
+/// Provides rendering for Obsidian Tags for Markdig.
+/// </summary>
+public class ObsidianTagsRenderer : HtmlObjectRenderer<Tag>
+{
+    /// <inheritdoc />
+    protected override void Write(HtmlRenderer renderer, Tag obj)
+    {
+        if (!renderer.EnableHtmlForInline)
+        {
+            return;
+        }
+
+        renderer.Write(/*lang=html*/"<span class=\"tag\">");
+        renderer.Write(obj.Name);
+        renderer.WriteAttributes(obj);
+        renderer.Write(/*lang=html*/"</span>");
+    }
+}

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/Tag.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/Tags/Tag.cs
@@ -1,0 +1,15 @@
+using Markdig.Syntax.Inlines;
+
+namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.Tags;
+
+/// <summary>
+/// Defines an Obsidian Tag within a Markdown document.
+/// </summary>
+/// <inheritdoc />
+public sealed class Tag(string name) : Inline
+{
+    /// <summary>
+    /// The name of the tag.
+    /// </summary>
+    public string Name { get; } = name;
+}


### PR DESCRIPTION
Implements display support for Obsidian Tags via a new Markdig extension.
Closes #33.