### PR TITLE
Vault edition: Use Streams instead of Buffers

### DIFF
--- a/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using Nodsoft.MoltenObsidian.Utilities;
 using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Blazor.Helpers;

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/InternalLink.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/InternalLink.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
-using Nodsoft.MoltenObsidian.Utilities;
 using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.InternalLinks;

--- a/Nodsoft.MoltenObsidian/Vault/IWritableVault.cs
+++ b/Nodsoft.MoltenObsidian/Vault/IWritableVault.cs
@@ -29,18 +29,12 @@ public interface IWritableVault : IVault
 	ValueTask DeleteFolderAsync(string path);
 	
 	/// <summary>
-	/// Writes content to a specified file, creating the file if it does not exist.
+	/// Writes the streamed content to a specified file, creating the file if it does not exist.
 	/// </summary>
-	/// <remarks>
-	///	If the file already exists, it will be overwritten.
-	///	If the file's path hits a missing folder, the folder will be created.
-	/// </remarks>
-	/// <param name="path">The path of the file to create.</param>
-	/// <param name="content">The content of the file to create.</param>
-	/// <returns>A task that holds the newly created file as its result.</returns>
-	/// <exception cref="ArgumentException">Thrown if the specified path is invalid.</exception>
-	/// <exception cref="IOException">Thrown if an I/O error occurs.</exception>
-	ValueTask<IVaultFile> WriteFileAsync(string path, byte[] content);
+	/// <param name="path">The path of the file to write to.</param>
+	/// <param name="content">The streamed content to write to the file.</param>
+	/// <returns>A task that holds the file as its result.</returns>
+	ValueTask<IVaultFile> WriteFileAsync(string path, Stream content);
 	
 	/// <summary>
 	/// Deletes the file with the specified path.
@@ -51,21 +45,20 @@ public interface IWritableVault : IVault
 	/// <exception cref="IOException">Thrown if an I/O error occurs.</exception>
 	ValueTask DeleteFileAsync(string path);
 	
-	
 	/// <summary>
-	/// Writes content to a specified note, creating the note if it does not exist.
+	/// Writes streamed content to a specified note, creating the note if it does not exist.
 	/// </summary>
 	/// <remarks>
 	/// If the note already exists, it will be overwritten.
 	/// If the note's path hits a missing folder, the folder will be created.
 	/// </remarks>
-	/// <param name="path">The path of the note to create.</param>
-	/// <param name="content">The content of the note to create.</param>
-	/// <returns>A task that holds the newly created note as its result.</returns>
+	/// <param name="path">The path of the note to write to.</param>
+	/// <param name="content">The streamed content to write to the note.</param>
+	/// <returns>A task that holds the note as its result.</returns>
 	/// <exception cref="ArgumentException">Thrown if the specified path is invalid.</exception>
 	/// <exception cref="IOException">Thrown if an I/O error occurs.</exception>
-	/// <seealso cref="WriteFileAsync(string, byte[])"/>
-	ValueTask<IVaultNote> WriteNoteAsync(string path, byte[] content);
+	/// <seealso cref="WriteFileAsync(string, Stream)"/>
+	ValueTask<IVaultNote> WriteNoteAsync(string path, Stream content);
 
 	/// <summary>
 	/// Deletes the note with the specified path.

--- a/Nodsoft.MoltenObsidian/VaultExtensions.cs
+++ b/Nodsoft.MoltenObsidian/VaultExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Nodsoft.MoltenObsidian.Vault;
 
-namespace Nodsoft.MoltenObsidian.Utilities;
+namespace Nodsoft.MoltenObsidian;
 
 /// <summary>
 /// Verious extension methods for the <see cref="IVault"/> interface and its dependents.
@@ -26,7 +26,7 @@ public static class VaultExtensions
 		
 		// All directories? Okay. Get ready for quite a bit of recursion.
 		// Traverse the subfolders.
-		Dictionary<string, IVaultFile> files = new();
+		Dictionary<string, IVaultFile> files = [];
 		_FolderTraversal(folder, ref files);
 		
 		return files;
@@ -78,7 +78,7 @@ public static class VaultExtensions
 		
 		// All directories? Okay. Get ready for quite a bit of recursion.
 		// Traverse the subfolders.
-		Dictionary<string, IVaultFolder> folders = new();
+		Dictionary<string, IVaultFolder> folders = [];
 		_FolderTraversal(folder, ref folders);
 		
 		return folders;
@@ -210,5 +210,44 @@ public static class VaultExtensions
 			// And when all else fails...
 			return null;
 		}
+	}
+
+	/// <summary>
+	/// Writes content to a specified file, creating the file if it does not exist.
+	/// </summary>
+	/// <remarks>
+	///	If the file already exists, it will be overwritten.
+	///	If the file's path hits a missing folder, the folder will be created.
+	/// </remarks>
+	/// <param name="vault">The vault to write to.</param>
+	/// <param name="path">The path of the file to write to.</param>
+	/// <param name="content">The content to write to the file.</param>
+	/// <returns>A task that holds the file as its result.</returns>
+	/// <exception cref="ArgumentException">Thrown if the specified path is invalid.</exception>
+	/// <exception cref="IOException">Thrown if an I/O error occurs.</exception>
+	public static async ValueTask<IVaultFile> WriteFileAsync(this IWritableVault vault, string path, byte[] content)
+	{
+		await using MemoryStream ms = new(content);
+		return await vault.WriteFileAsync(path, ms);
+	}
+	
+	/// <summary>
+	/// Writes content to a specified note, creating the note if it does not exist.
+	/// </summary>
+	/// <remarks>
+	/// If the note already exists, it will be overwritten.
+	/// If the note's path hits a missing folder, the folder will be created.
+	/// </remarks>
+	/// <param name="vault">The vault to write to.</param>
+	/// <param name="path">The path of the note to write to.</param>
+	/// <param name="content">The content to write to the note.</param>
+	/// <returns>A task that holds the note as its result.</returns>
+	/// <exception cref="ArgumentException">Thrown if the specified path is invalid.</exception>
+	/// <exception cref="IOException">Thrown if an I/O error occurs.</exception>
+	/// <seealso cref="WriteFileAsync(IWritableVault, string, byte[])" />
+	public static async ValueTask<IVaultNote> WriteNoteAsync(this IWritableVault vault, string path, byte[] content)
+	{
+		await using MemoryStream ms = new(content);
+		return (IVaultNote)await vault.WriteFileAsync(path, ms);
 	}
 }

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/Data/FileSystemVaultFile.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/Data/FileSystemVaultFile.cs
@@ -44,13 +44,13 @@ internal class FileSystemVaultFile : FileSystemVaultEntityBase, IVaultFile
 	/// <param name="parent">The parent folder of the file to create.</param>
 	/// <param name="vault">The vault that the file belongs to.</param>
 	/// <returns>The newly created <see cref="FileSystemVaultFile"/> instance.</returns>
-	public static async ValueTask<FileSystemVaultFile> WriteFileAsync(string path, ReadOnlyMemory<byte> content, IVaultFolder parent, FileSystemVault vault)
+	public static async ValueTask<FileSystemVaultFile> WriteFileAsync(string path, Stream content, IVaultFolder parent, FileSystemVault vault)
 	{
 		string fullPath = System.IO.Path.Join(((FileSystemVaultFolder)vault.Root).PhysicalDirectoryInfo.FullName, path);
 		bool fileExists = File.Exists(fullPath);
 		
 		await using FileStream fs = File.Open(fullPath, FileMode.Create, FileAccess.Write);
-		await fs.WriteAsync(content);
+		await content.CopyToAsync(fs);
 		fs.Flush();
 		
 		FileSystemVaultFile file = parent.Files.FirstOrDefault(f => f.Path == path) as FileSystemVaultFile 

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/FileSystemVault.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/FileSystemVault.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Concurrent;
 using JetBrains.Annotations;
-using Nodsoft.MoltenObsidian.Utilities;
 using Nodsoft.MoltenObsidian.Vault;
 using Nodsoft.MoltenObsidian.Vaults.FileSystem.Data;
 
@@ -290,7 +289,7 @@ public sealed class FileSystemVault : IWritableVault
 	}
 
 	/// <inheritdoc />
-	public async ValueTask<IVaultFile> WriteFileAsync(string path, byte[] content)
+	public async ValueTask<IVaultFile> WriteFileAsync(string path, Stream content)
 	{
 		// Small step: Strip the leading slash if present
 		if (path.StartsWith('/'))
@@ -321,7 +320,7 @@ public sealed class FileSystemVault : IWritableVault
 	}
 
 	/// <inheritdoc />
-	public async ValueTask<IVaultNote> WriteNoteAsync(string path, byte[] content)
+	public async ValueTask<IVaultNote> WriteNoteAsync(string path, Stream content)
 	{
 		// This is just a wrapper around CreateFileAsync with a check for the extension.
 		if (!path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Changed the `IWritableVault` interface to mandate streams. Buffer implementations are moved to an extension class.