### PR TITLE
v1.1 - Drop support for .NET 6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
@@ -34,11 +34,11 @@
 
 	<ItemGroup>
 		<!-- Nerdbank.GitVersioning -->
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" Condition="!Exists('packages.config')" PrivateAssets="all" />
+		<PackageReference Include="Nerdbank.GitVersioning" Version="3.6.141" Condition="!Exists('packages.config')" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(PackAsTool) != 'true'">
-		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
+		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.4" PrivateAssets="All"/>
 	</ItemGroup>
 	
 	<ItemGroup Label="PackageInfoFiles">

--- a/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultComponentHelpers.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultComponentHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Components;
 
 namespace Nodsoft.MoltenObsidian.Blazor.Helpers;
@@ -7,13 +8,15 @@ namespace Nodsoft.MoltenObsidian.Blazor.Helpers;
 /// <summary>
 /// Provides helper methods for working with Vault implementation components.
 /// </summary>
-public static class VaultComponentHelpers
+[PublicAPI]
+public static partial class VaultComponentHelpers
 {
 	/// <summary>
 	/// Regex for matching a slug segment at the end of a string. (e.g. "/{*slugName}")
 	/// This is the same regex used by the Blazor Router to match slug segments.
 	/// </summary>
-	private static readonly Regex SlugRegex = new(@"\/\{\*[\w\d]+\}$", RegexOptions.Compiled);
+	[GeneratedRegex(@"\/\{\*[\w\d]+\}$", RegexOptions.Compiled)]
+	private static partial Regex SlugRegex();
 	
 	/// <summary>
 	/// A dictionary containing the base vault path for a component type.
@@ -56,8 +59,8 @@ public static class VaultComponentHelpers
 		
 		// Second. Does the RouteAttribute have a slug segment at the end?
 		// If so, remove it.
-		string basePath = SlugRegex.IsMatch(routeAttribute.Template) 
-			? SlugRegex.Replace(routeAttribute.Template, string.Empty) 
+		string basePath = SlugRegex().IsMatch(routeAttribute.Template) 
+			? SlugRegex().Replace(routeAttribute.Template, string.Empty) 
 			: routeAttribute.Template;
 		
 		// Third. Does the base path end with slashes?

--- a/Nodsoft.MoltenObsidian.Blazor/Nodsoft.MoltenObsidian.Blazor.csproj
+++ b/Nodsoft.MoltenObsidian.Blazor/Nodsoft.MoltenObsidian.Blazor.csproj
@@ -10,15 +10,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Nodsoft.MoltenObsidian\Nodsoft.MoltenObsidian.csproj" />		
+		<ProjectReference Include="..\Nodsoft.MoltenObsidian\Nodsoft.MoltenObsidian.csproj" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.3" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.28" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
 	</ItemGroup>
 	
 </Project>

--- a/Nodsoft.MoltenObsidian.Manifest/Nodsoft.MoltenObsidian.Manifest.csproj
+++ b/Nodsoft.MoltenObsidian.Manifest/Nodsoft.MoltenObsidian.Manifest.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MimeTypes" Version="2.5.1">
+		<PackageReference Include="MimeTypes" Version="2.5.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
+++ b/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
@@ -13,9 +13,9 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Nodsoft.MoltenObsidian.Tool/Nodsoft.MoltenObsidian.Tool.csproj
+++ b/Nodsoft.MoltenObsidian.Tool/Nodsoft.MoltenObsidian.Tool.csproj
@@ -17,8 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
 		<PackageReference Include="Throw" Version="1.4.0" />
 	</ItemGroup>
 

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/InternalLink.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/InternalLink.cs
@@ -11,7 +11,7 @@ namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.InternalLinks;
 ///	Syntax: <c>[[link]] | [[link|display]] | [[link|display|tooltip]]</c>
 /// The link can be a relative path, an absolute path, and/or a section anchor.
 /// </example>
-public sealed class InternalLink : LinkInline
+public sealed partial class InternalLink : LinkInline
 {
 	/// <summary>
 	/// Initializes a new instance of the <see cref="InternalLink"/> class.
@@ -24,7 +24,8 @@ public sealed class InternalLink : LinkInline
 	/// <summary>
 	/// Regex substitution pattern for internal link anchors, to replace spaces with dashes and remove all other invalid characters.
 	/// </summary>
-	private static readonly Regex AnchorRegex = new(@"[^\w.]+", RegexOptions.Compiled);
+	[GeneratedRegex(@"[^\w.]+", RegexOptions.Compiled | RegexOptions.NonBacktracking)]
+	private static partial Regex AnchorRegex();
 
 	
 	/// <summary>
@@ -44,7 +45,7 @@ public sealed class InternalLink : LinkInline
 	/// <summary>
 	/// The fragment of the section anchor, suitable for use in a URL.
 	/// </summary>
-	public string? TargetSectionLinkFragment => TargetSection is null ? null : AnchorRegex.Replace(TargetSection, "-").Trim('-').ToLowerInvariant();
+	public string? TargetSectionLinkFragment => TargetSection is null ? null : AnchorRegex().Replace(TargetSection, "-").Trim('-').ToLowerInvariant();
 	
 	/// <summary>
 	/// The display text of the internal link, if any.

--- a/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/ObsidianInternalLinksParser.cs
+++ b/Nodsoft.MoltenObsidian/Infrastructure/Markdown/InternalLinks/ObsidianInternalLinksParser.cs
@@ -10,7 +10,7 @@ namespace Nodsoft.MoltenObsidian.Infrastructure.Markdown.InternalLinks;
 /// Provides parsing for Obsidian internal links for Markdig.
 /// </summary>
 /// <seealso cref="InternalLink" />
-public sealed class ObsidianInternalLinksParser : InlineParser
+public sealed partial class ObsidianInternalLinksParser : InlineParser
 {
 	/// <summary>
 	/// Regex pattern with named variables for internal links.
@@ -23,22 +23,20 @@ public sealed class ObsidianInternalLinksParser : InlineParser
 	/// [[note_one|not note one]]
 	/// [[note#section|display|tooltip]]
 	/// </example>
-	private static readonly Regex InternalLinkRegex = new(
+	[GeneratedRegex(
 		"""
-			^\[\[(
-				# link, and optional anchor
-				(?<link>[^\|\#\]]+)?(\#(?<anchor>[^\|\]]+))?
-				# display title (optional)
-				(\|(?<title>[^|\]]+))?
-				# tooltip (optional)
-				(\|(?<tooltip>[^|\]]+))?
-			)\]\]
-		""",
-		RegexOptions.Compiled 
-		| RegexOptions.IgnorePatternWhitespace 
-		| RegexOptions.ExplicitCapture 
-		| RegexOptions.Multiline
-	);
+		^\[\[(
+			# link, and optional anchor
+			(?<link>[^\|\#\]]+)?(\#(?<anchor>[^\|\]]+))?
+			
+			# display title (optional)
+			(\|(?<title>[^|\]]+))?
+			
+			# tooltip (optional)
+			(\|(?<tooltip>[^|\]]+))?
+		)\]\]
+		""", RegexOptions.Multiline | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace | RegexOptions.NonBacktracking)]
+	private static partial Regex InternalLinkRegex();
 	
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ObsidianInternalLinksParser"/> class.
@@ -49,7 +47,7 @@ public sealed class ObsidianInternalLinksParser : InlineParser
 	}
 
 	/// <inheritdoc />
-	public override bool Match(InlineProcessor processor, ref StringSlice slice)
+	public override bool Match(InlineProcessor processor, scoped ref StringSlice slice)
 	{
 		// Seek to the first two opening brackets
 		if (slice.CurrentChar is not '[' && slice.PeekChar() is not '[')
@@ -58,7 +56,7 @@ public sealed class ObsidianInternalLinksParser : InlineParser
 		}
 
 		// Grab the remainder of the slice, and check if it matches the internal link pattern.
-		Match match = InternalLinkRegex.Match(slice.Text[slice.Start..slice.End]);
+		Match match = InternalLinkRegex().Match(slice.Text[slice.Start..slice.End]);
 
 		if (match is { Groups: [{ Name: "0" }]})
 		{

--- a/Nodsoft.MoltenObsidian/Nodsoft.MoltenObsidian.csproj
+++ b/Nodsoft.MoltenObsidian/Nodsoft.MoltenObsidian.csproj
@@ -5,10 +5,10 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-		<PackageReference Include="Markdig" Version="0.36.2" />
+		<PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+		<PackageReference Include="Markdig" Version="0.37.0" />
 		<PackageReference Include="Nodsoft.Markdig.SyntaxHighlighting" Version="1.0.12" />
-		<PackageReference Include="YamlDotNet" Version="15.1.2" />
+		<PackageReference Include="YamlDotNet" Version="16.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Samples/Nodsoft.MoltenObsidian.Samples.FtpWasm/Nodsoft.MoltenObsidian.Samples.FtpWasm.csproj
+++ b/Samples/Nodsoft.MoltenObsidian.Samples.FtpWasm/Nodsoft.MoltenObsidian.Samples.FtpWasm.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.11" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.11" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/Samples/Nodsoft.MoltenObsidian.Samples.Wasm/Nodsoft.MoltenObsidian.Samples.Wasm.csproj
+++ b/Samples/Nodsoft.MoltenObsidian.Samples.Wasm/Nodsoft.MoltenObsidian.Samples.Wasm.csproj
@@ -5,8 +5,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.11" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Vaults/Directory.Build.props
+++ b/Vaults/Directory.Build.props
@@ -13,8 +13,4 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-	</ItemGroup>
 </Project>

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Nodsoft.MoltenObsidian.Vaults.Ftp.csproj
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Nodsoft.MoltenObsidian.Vaults.Ftp.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Nodsoft.MoltenObsidian.Manifest\Nodsoft.MoltenObsidian.Manifest.csproj" />
 
-        <PackageReference Include="FluentFTP" Version="46.0.2" />
+        <PackageReference Include="FluentFTP" Version="51.0.0" />
     </ItemGroup>
     
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
- Dropped support for .NET 6.0 ; Now supporting .NET 8.0+.
- Updated regex implementation to use new .NET 7 sourcegen implementations.
- Bumped version to v1.1, to reflect breaking change.