### PR TITLE
Add tests for Blazor components and code

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,6 +54,9 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>Nodsoft.MoltenObsidian.Tests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Nodsoft.MoltenObsidian.Blazor.Tests</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 	
 </Project>

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultDisplayTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultDisplayTests.cs
@@ -1,0 +1,286 @@
+using System.Text;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Nodsoft.MoltenObsidian.Blazor.Services;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Components;
+
+/// <summary>
+/// Provides tests for the <see cref="ObsidianVaultDisplay"/> Razor component.
+/// </summary>
+/// <seealso cref="ObsidianVaultDisplay"/>
+public sealed class ObsidianVaultDisplayTests : IDisposable
+{
+	private readonly BunitContext _ctx;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ObsidianVaultDisplayTests"/> class.
+	/// </summary>
+	public ObsidianVaultDisplayTests()
+	{
+		_ctx = new BunitContext();
+
+		// Use loose JSInterop mode so that eval() calls in OnAfterRenderAsync do not throw.
+		_ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+		// Register the required VaultRouterFactory service.
+		_ctx.Services.AddSingleton<VaultRouterFactory>();
+	}
+
+	/// <inheritdoc/>
+	public void Dispose() => _ctx.Dispose();
+
+	/// <summary>
+	/// Renders the <see cref="ObsidianVaultDisplay"/> component and returns it.
+	/// </summary>
+	private IRenderedComponent<ObsidianVaultDisplay> RenderDisplay(
+		InMemoryVault vault,
+		string currentPath = "/",
+		string basePath = "/",
+		ObsidianVaultDisplayOptions? options = null)
+		=> _ctx.Render<ObsidianVaultDisplay>(p => p
+			.Add(c => c.Vault, vault)
+			.Add(c => c.CurrentPath, currentPath)
+			.Add(c => c.BasePath, basePath)
+			.Add(c => c.Options, options ?? new ObsidianVaultDisplayOptions()));
+
+	/// <summary>
+	/// Tests that navigating to the vault root (empty path) renders the vault root template
+	/// when there is no index note.
+	/// </summary>
+	[Fact]
+	public async Task Render_RootPathNoIndex_RendersVaultRootTemplate()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("some-note.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/");
+
+		// Assert – the default FoundVaultRoot template renders a <nav> with the vault name
+		AngleSharp.Dom.IElement nav = cut.Find("nav");
+		Assert.Contains("TestVault", nav.GetAttribute("name") ?? string.Empty);
+	}
+
+	/// <summary>
+	/// Tests that navigating to the vault root renders the index note template
+	/// when an index note (README.md) is present.
+	/// </summary>
+	[Fact]
+	public async Task Render_RootPathWithIndexNote_RendersFoundIndexNoteTemplate()
+	{
+		// Arrange
+		const string content = "# Welcome";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/");
+
+		// Assert – FoundIndexNote template renders an <article> element
+		cut.Find("article");
+	}
+
+	/// <summary>
+	/// Tests that navigating to an existing note renders the found-note template.
+	/// </summary>
+	[Fact]
+	public async Task Render_NotePath_RendersFoundNoteTemplate()
+	{
+		// Arrange
+		const string content = "# My Note";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("my-note.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "my-note");
+
+		// Assert – the default FoundNote template renders an <article> element
+		AngleSharp.Dom.IElement article = cut.Find("article");
+		Assert.Equal("my-note.md", article.GetAttribute("name"));
+	}
+
+	/// <summary>
+	/// Tests that navigating to a folder path without an index note renders the found-folder template.
+	/// </summary>
+	[Fact]
+	public async Task Render_FolderPathNoIndex_RendersFoundFolderTemplate()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "section");
+
+		// Assert – the default FoundFolder template renders a <nav> element with folder name
+		AngleSharp.Dom.IElement nav = cut.Find("nav");
+		Assert.Equal("section", nav.GetAttribute("name"));
+	}
+
+	/// <summary>
+	/// Tests that navigating to a folder that has an index note renders the found-index-note template.
+	/// </summary>
+	[Fact]
+	public async Task Render_FolderPathWithIndexNote_RendersFoundIndexNoteTemplate()
+	{
+		// Arrange
+		const string content = "# Section Index";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/index.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "section");
+
+		// Assert – FoundIndexNote template renders an <article class="moltenobsidian-index-note"> element
+		cut.Find("article.moltenobsidian-index-note");
+	}
+
+	/// <summary>
+	/// Tests that navigating to a non-existent path renders the not-found template.
+	/// </summary>
+	[Fact]
+	public void Render_NonExistentPath_RendersNotFoundTemplate()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "does-not-exist");
+
+		// Assert – the default NotFound template renders a <div> with a "No result." heading
+		AngleSharp.Dom.IElement heading = cut.Find("h1");
+		Assert.Equal("No result.", heading.TextContent);
+	}
+
+	/// <summary>
+	/// Tests that a custom <see cref="ObsidianVaultDisplay.NotFound"/> render fragment is invoked
+	/// when the path does not match any entity.
+	/// </summary>
+	[Fact]
+	public void Render_CustomNotFoundFragment_IsRendered()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		RenderFragment<Templates.NotFound.NotFoundRenderContext> customNotFound =
+			ctx => builder =>
+			{
+				builder.OpenElement(0, "section");
+				builder.AddAttribute(1, "id", "custom-not-found");
+				builder.CloseElement();
+			};
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = _ctx.Render<ObsidianVaultDisplay>(p => p
+			.Add(c => c.Vault, vault)
+			.Add(c => c.CurrentPath, "missing")
+			.Add(c => c.BasePath, "/")
+			.Add(c => c.NotFound, customNotFound));
+
+		// Assert – the custom element is rendered (confirming custom fragment is used)
+		cut.Find("section#custom-not-found");
+	}
+
+	/// <summary>
+	/// Tests that a custom <see cref="ObsidianVaultDisplay.FoundNote"/> render fragment is invoked
+	/// when a note is found.
+	/// </summary>
+	[Fact]
+	public async Task Render_CustomFoundNoteFragment_IsRendered()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("doc.md", Stream.Null);
+
+		RenderFragment<Templates.FoundNote.FoundNoteRenderContext> customFoundNote =
+			ctx => builder =>
+			{
+				builder.OpenElement(0, "section");
+				builder.AddAttribute(1, "id", "custom-note");
+				builder.AddContent(2, ctx.Note.Name);
+				builder.CloseElement();
+			};
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = _ctx.Render<ObsidianVaultDisplay>(p => p
+			.Add(c => c.Vault, vault)
+			.Add(c => c.CurrentPath, "doc")
+			.Add(c => c.BasePath, "/")
+			.Add(c => c.FoundNote, customFoundNote));
+
+		// Assert
+		AngleSharp.Dom.IElement section = cut.Find("section#custom-note");
+		Assert.Equal("doc.md", section.TextContent);
+	}
+
+	/// <summary>
+	/// Tests that with <see cref="ObsidianVaultDisplayOptions.DisplayIndexNoteNavigation"/> disabled,
+	/// the index note template does not render the folder navigation tree.
+	/// </summary>
+	[Fact]
+	public async Task Render_IndexNoteNavigationDisabled_OmitsFolderNav()
+	{
+		// Arrange
+		const string content = "# Root";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+		await vault.WriteNoteAsync("other.md", Stream.Null);
+
+		ObsidianVaultDisplayOptions options = new() { DisplayIndexNoteNavigation = false };
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/", options: options);
+
+		// Assert – the folder nav should not be present
+		Assert.Throws<ElementNotFoundException>(
+			() => cut.Find("nav.moltenobsidian-folder-nav")
+		);
+	}
+
+	/// <summary>
+	/// Tests that with <see cref="ObsidianVaultDisplayOptions.DisplayIndexNoteNavigation"/> enabled,
+	/// the index note template also renders the folder navigation.
+	/// </summary>
+	[Fact]
+	public async Task Render_IndexNoteNavigationEnabled_IncludesFolderNav()
+	{
+		// Arrange
+		const string content = "# Root";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+		await vault.WriteNoteAsync("other.md", Stream.Null);
+
+		ObsidianVaultDisplayOptions options = new() { DisplayIndexNoteNavigation = true };
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/", options: options);
+
+		// Assert – folder nav is rendered
+		cut.Find("nav.moltenobsidian-folder-nav");
+	}
+
+	/// <summary>
+	/// Tests that the display throws <see cref="InvalidOperationException"/> when no router is available.
+	/// </summary>
+	[Fact]
+	public void Render_WithoutRouterFactory_ThrowsInvalidOperationException()
+	{
+		// Arrange – no VaultRouterFactory registered, and no Router set
+		using BunitContext ctx = new();
+		ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+		InMemoryVault vault = new("TestVault");
+
+		// Act & Assert
+		Assert.Throws<InvalidOperationException>(() =>
+			ctx.Render<ObsidianVaultDisplay>(p => p
+				.Add(c => c.Vault, vault)
+				.Add(c => c.CurrentPath, "doc")
+				.Add(c => c.BasePath, "/"))
+		);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultNavigationTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultNavigationTests.cs
@@ -1,0 +1,212 @@
+using Bunit;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Components;
+
+/// <summary>
+/// Provides tests for the <see cref="ObsidianVaultNavigation"/> Razor component.
+/// </summary>
+/// <seealso cref="ObsidianVaultNavigation"/>
+public sealed class ObsidianVaultNavigationTests : IDisposable
+{
+	private readonly BunitContext _ctx;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ObsidianVaultNavigationTests"/> class.
+	/// </summary>
+	public ObsidianVaultNavigationTests()
+	{
+		_ctx = new BunitContext();
+	}
+
+	/// <inheritdoc/>
+	public void Dispose() => _ctx.Dispose();
+
+	/// <summary>
+	/// Tests that the navigation component renders a &lt;nav&gt; element for an empty vault.
+	/// </summary>
+	[Fact]
+	public void Render_EmptyVault_RendersNavElement()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – a <nav> element must be present at the root
+		cut.Find("nav");
+	}
+
+	/// <summary>
+	/// Tests that notes in the root of the vault are rendered as anchor links.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithRootNote_RendersNoteLink()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("my-note.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – a link to "my-note" (without .md) must be present
+		AngleSharp.Dom.IElement link = cut.Find("a[href='my-note']");
+		Assert.Equal("my-note", link.TextContent);
+	}
+
+	/// <summary>
+	/// Tests that multiple notes are all rendered as links.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithMultipleNotes_RendersAllNoteLinks()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("alpha.md", Stream.Null);
+		await vault.WriteNoteAsync("beta.md", Stream.Null);
+		await vault.WriteNoteAsync("gamma.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert
+		cut.Find("a[href='alpha']");
+		cut.Find("a[href='beta']");
+		cut.Find("a[href='gamma']");
+	}
+
+	/// <summary>
+	/// Tests that a subfolder is rendered inside a wrapping &lt;div&gt; element.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithSubfolder_RendersSubfolderDiv()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – a nested note link for "section/page" must be present
+		cut.Find("a[href='section/page']");
+	}
+
+	/// <summary>
+	/// Tests that the ".obsidian" system folder is hidden from the navigation tree.
+	/// </summary>
+	[Fact]
+	public async Task Render_ObsidianSystemFolder_IsHidden()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync(".obsidian/config.md", Stream.Null);
+		await vault.WriteNoteAsync("visible-note.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – the ".obsidian" folder link must not appear
+		Assert.Throws<ElementNotFoundException>(
+			() => cut.Find("a[href='.obsidian/']")
+		);
+
+		// But the visible note must still appear
+		cut.Find("a[href='visible-note']");
+	}
+
+	/// <summary>
+	/// Tests that a subfolder with an index note is rendered as a link (with trailing slash).
+	/// </summary>
+	[Fact]
+	public async Task Render_SubfolderWithIndexNote_RendersFolderAsLink()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/index.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – the folder should have a link ending with "/"
+		cut.Find("a[href='section/']");
+	}
+
+	/// <summary>
+	/// Tests that a subfolder without an index note is rendered as a non-link div.
+	/// </summary>
+	[Fact]
+	public async Task Render_SubfolderWithoutIndexNote_RendersFolderAsDiv()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – the folder should NOT have a direct link (no <a> for the folder itself)
+		Assert.Throws<ElementNotFoundException>(
+			() => cut.Find("a[href='section/']")
+		);
+	}
+
+	/// <summary>
+	/// Tests that custom navigation attributes are applied to the &lt;nav&gt; element.
+	/// </summary>
+	[Fact]
+	public void Render_WithCustomNavigationAttributes_AppliesAttributes()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+				.Add(c => c.NavigationAttributes, _ => new() { ["class"] = "my-nav", ["id"] = "sidebar" })
+		);
+
+		// Assert
+		AngleSharp.Dom.IElement nav = cut.Find("nav");
+		Assert.Equal("my-nav", nav.GetAttribute("class"));
+		Assert.Equal("sidebar", nav.GetAttribute("id"));
+	}
+
+	/// <summary>
+	/// Tests that custom note attributes are applied to the note link elements.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithCustomNoteAttributes_AppliesAttributesToLinks()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+				.Add(c => c.NoteAttributes, _ => new() { ["class"] = "note-link" })
+		);
+
+		// Assert
+		AngleSharp.Dom.IElement link = cut.Find("a[href='page']");
+		Assert.Equal("note-link", link.GetAttribute("class"));
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultComponentHelpersTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultComponentHelpersTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.AspNetCore.Components;
+using Nodsoft.MoltenObsidian.Blazor.Helpers;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Helpers;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultComponentHelpers"/> class.
+/// </summary>
+/// <seealso cref="VaultComponentHelpers"/>
+public sealed class VaultComponentHelpersTests
+{
+	/// <summary>
+	/// A fake component with a route that has a catch-all slug segment.
+	/// </summary>
+	[Route("/vault/{*slug}")]
+	private sealed class ComponentWithSlugRoute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// A fake component with a simple route that has no trailing slug.
+	/// </summary>
+	[Route("/docs")]
+	private sealed class ComponentWithSimpleRoute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// A fake component with a nested route that has a catch-all slug segment.
+	/// </summary>
+	[Route("/content/section/{*slug}")]
+	private sealed class ComponentWithNestedSlugRoute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// A fake component with no <see cref="RouteAttribute"/>.
+	/// </summary>
+	private sealed class ComponentWithoutRouteAttribute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Tests that a component with a slug segment at the end has the slug stripped,
+	/// returning just the base path with a trailing slash.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithSlugRoute_ReturnsBasePath()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSlugRoute>();
+
+		// Assert
+		Assert.Equal("/vault/", basePath);
+	}
+
+	/// <summary>
+	/// Tests that a component with a simple route (no slug) returns the route with a trailing slash appended.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithSimpleRoute_ReturnsRouteWithTrailingSlash()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSimpleRoute>();
+
+		// Assert
+		Assert.Equal("/docs/", basePath);
+	}
+
+	/// <summary>
+	/// Tests that a component with a nested slug route returns the correct base path.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithNestedSlugRoute_ReturnsNestedBasePath()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithNestedSlugRoute>();
+
+		// Assert
+		Assert.Equal("/content/section/", basePath);
+	}
+
+	/// <summary>
+	/// Tests that calling the method twice for the same component type returns the same value (caching).
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_SameComponentType_ReturnsCachedResult()
+	{
+		// Act
+		string first = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSlugRoute>();
+		string second = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSlugRoute>();
+
+		// Assert
+		Assert.Equal(first, second);
+	}
+
+	/// <summary>
+	/// Tests that a component without a <see cref="RouteAttribute"/> throws <see cref="ArgumentException"/>.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithoutRouteAttribute_ThrowsArgumentException()
+	{
+		// Act & Assert
+		Assert.Throws<ArgumentException>(
+			() => VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithoutRouteAttribute>()
+		);
+	}
+
+	/// <summary>
+	/// Tests that the base path always ends with a trailing slash.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ResultAlwaysHasTrailingSlash()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSimpleRoute>();
+
+		// Assert
+		Assert.EndsWith("/", basePath);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultNavigationHelpersTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultNavigationHelpersTests.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using Nodsoft.MoltenObsidian.Blazor.Helpers;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Helpers;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultNavigationHelpers"/> class.
+/// </summary>
+/// <seealso cref="VaultNavigationHelpers"/>
+public sealed class VaultNavigationHelpersTests
+{
+	/// <summary>
+	/// Tests that a folder containing a "README.md" file returns it as the index note.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_WithReadmeMd_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("README.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that a folder containing an "index.md" file returns it as the index note.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_WithIndexMd_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("index.md", Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("index.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that "README.md" detection is case-insensitive.
+	/// </summary>
+	[Theory]
+	[InlineData("readme.md")]
+	[InlineData("Readme.md")]
+	[InlineData("README.MD")]
+	public async Task GetIndexNoteAsync_ReadmeMdCaseInsensitive_ReturnsNote(string filename)
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync(filename, Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+	}
+
+	/// <summary>
+	/// Tests that "index.md" detection is case-insensitive.
+	/// </summary>
+	[Theory]
+	[InlineData("index.md")]
+	[InlineData("Index.md")]
+	[InlineData("INDEX.MD")]
+	public async Task GetIndexNoteAsync_IndexMdCaseInsensitive_ReturnsNote(string filename)
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync(filename, Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+	}
+
+	/// <summary>
+	/// Tests that a folder with no index note returns null.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_NoIndexNote_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("other-note.md", Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that an empty folder returns null.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_EmptyFolder_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that an index note with frontmatter setting "moltenobsidian:index:enabled" to false
+	/// is not returned as the index note.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_DisabledByFrontmatter_ReturnsNull()
+	{
+		// Arrange
+		const string content = """
+			---
+			moltenobsidian:index:enabled: false
+			---
+
+			# Hidden Index
+			""";
+
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that an index note with frontmatter not setting "moltenobsidian:index:enabled"
+	/// is returned normally.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_FrontmatterWithoutIndexKey_ReturnsNote()
+	{
+		// Arrange
+		const string content = """
+			---
+			title: Home
+			---
+
+			# Home
+			""";
+
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+	}
+
+	/// <summary>
+	/// Tests that an index note inside a subfolder is also correctly detected.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_IndexNoteInSubfolder_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/README.md", Stream.Null);
+
+		IVaultFolder? subfolder = (vault as IVault).GetFolder("section");
+
+		// Act
+		IVaultNote? result = await subfolder!.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("section/README.md", result.Path);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Nodsoft.MoltenObsidian.Blazor.Tests.csproj
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Nodsoft.MoltenObsidian.Blazor.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="bunit" Version="2.7.2" />
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.v3.runner.msbuild" Version="3.2.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Nodsoft.MoltenObsidian.Blazor\Nodsoft.MoltenObsidian.Blazor.csproj" />
+        <ProjectReference Include="..\Vaults\Nodsoft.MoltenObsidian.Vaults.InMemory\Nodsoft.MoltenObsidian.Vaults.InMemory.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/ObsidianDependencyInjectionExtensionsTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/ObsidianDependencyInjectionExtensionsTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nodsoft.MoltenObsidian.Blazor.Services;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests;
+
+/// <summary>
+/// Provides tests for the <see cref="ObsidianDependencyInjectionExtensions"/> class.
+/// </summary>
+/// <seealso cref="ObsidianDependencyInjectionExtensions"/>
+public sealed class ObsidianDependencyInjectionExtensionsTests
+{
+	/// <summary>
+	/// Tests that <see cref="ObsidianDependencyInjectionExtensions.AddMoltenObsidianBlazorIntegration"/>
+	/// registers <see cref="VaultRouterFactory"/> as a singleton service.
+	/// </summary>
+	[Fact]
+	public void AddMoltenObsidianBlazorIntegration_RegistersVaultRouterFactory()
+	{
+		// Arrange
+		ServiceCollection services = new();
+
+		// Act
+		services.AddMoltenObsidianBlazorIntegration();
+		ServiceProvider provider = services.BuildServiceProvider();
+
+		// Assert
+		VaultRouterFactory? factory = provider.GetService<VaultRouterFactory>();
+		Assert.NotNull(factory);
+	}
+
+	/// <summary>
+	/// Tests that <see cref="VaultRouterFactory"/> is registered as a singleton
+	/// (the same instance is returned on successive resolutions).
+	/// </summary>
+	[Fact]
+	public void AddMoltenObsidianBlazorIntegration_VaultRouterFactory_IsSingleton()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		services.AddMoltenObsidianBlazorIntegration();
+		ServiceProvider provider = services.BuildServiceProvider();
+
+		// Act
+		VaultRouterFactory first = provider.GetRequiredService<VaultRouterFactory>();
+		VaultRouterFactory second = provider.GetRequiredService<VaultRouterFactory>();
+
+		// Assert – singleton: same instance every time
+		Assert.Same(first, second);
+	}
+
+	/// <summary>
+	/// Tests that <see cref="ObsidianDependencyInjectionExtensions.AddMoltenObsidianBlazorIntegration"/>
+	/// returns the same <see cref="IServiceCollection"/> instance to allow call chaining.
+	/// </summary>
+	[Fact]
+	public void AddMoltenObsidianBlazorIntegration_ReturnsServiceCollection()
+	{
+		// Arrange
+		ServiceCollection services = new();
+
+		// Act
+		IServiceCollection result = services.AddMoltenObsidianBlazorIntegration();
+
+		// Assert
+		Assert.Same(services, result);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterFactoryTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterFactoryTests.cs
@@ -1,0 +1,86 @@
+using Nodsoft.MoltenObsidian.Blazor.Services;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Services;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultRouterFactory"/> class.
+/// </summary>
+/// <seealso cref="VaultRouterFactory"/>
+public sealed class VaultRouterFactoryTests
+{
+	/// <summary>
+	/// Tests that requesting a router for the same vault instance returns the same cached router.
+	/// </summary>
+	[Fact]
+	public void GetRouter_SameVaultInstance_ReturnsCachedRouter()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter first = factory.GetRouter(vault);
+		VaultRouter second = factory.GetRouter(vault);
+
+		// Assert – must be the exact same instance
+		Assert.Same(first, second);
+	}
+
+	/// <summary>
+	/// Tests that requesting routers for two distinct vault instances returns different routers.
+	/// </summary>
+	[Fact]
+	public void GetRouter_DifferentVaultInstances_ReturnsDifferentRouters()
+	{
+		// Arrange
+		InMemoryVault vault1 = new("Vault1");
+		InMemoryVault vault2 = new("Vault2");
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter router1 = factory.GetRouter(vault1);
+		VaultRouter router2 = factory.GetRouter(vault2);
+
+		// Assert – must be different instances
+		Assert.NotSame(router1, router2);
+	}
+
+	/// <summary>
+	/// Tests that the router returned by the factory actually routes to the vault's contents.
+	/// </summary>
+	[Fact]
+	public async Task GetRouter_RouterRoutesToVaultContents()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("doc.md", Stream.Null);
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter router = factory.GetRouter(vault);
+		IVaultEntity? result = router.RouteTo("doc");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+	}
+
+	/// <summary>
+	/// Tests that the factory creates a new router for a previously unseen vault.
+	/// </summary>
+	[Fact]
+	public void GetRouter_NewVault_ReturnsNewRouter()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter router = factory.GetRouter(vault);
+
+		// Assert
+		Assert.NotNull(router);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
@@ -153,7 +153,7 @@ public sealed class VaultRouterTests
 	/// Tests that adding multiple notes are all registered in the routing table.
 	/// </summary>
 	[Fact]
-	public async Task RouteTo_MultipleNotes_AllRouteable()
+	public async Task RouteTo_MultipleNotes_AllRoutable()
 	{
 		// Arrange
 		InMemoryVault vault = new("TestVault");

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
@@ -1,0 +1,211 @@
+using System.Text;
+using Nodsoft.MoltenObsidian.Blazor.Services;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Services;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultRouter"/> class.
+/// </summary>
+/// <seealso cref="VaultRouter"/>
+public sealed class VaultRouterTests
+{
+	/// <summary>
+	/// Tests that routing to an existing folder returns the correct folder.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_ExistingFolder_ReturnsFolder()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.CreateFolderAsync("notes");
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("notes");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultFolder>(result);
+		Assert.Equal("notes", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that routing to an existing note (without ".md" extension) returns the correct note.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_ExistingNote_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("hello.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("hello");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+		Assert.Equal("hello.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that routing to an existing note in a subfolder returns the correct note.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_NoteInSubfolder_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("notes/page.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("notes/page");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+		Assert.Equal("notes/page.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that routing to a path that doesn't exist returns null.
+	/// </summary>
+	[Fact]
+	public void RouteTo_NonExistentPath_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("does-not-exist");
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that case-sensitive routing is preferred when an exact match is found.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_CaseSensitiveMatch_ReturnsEntity()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("MyNote.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("MyNote");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("MyNote.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that case-insensitive fallback routing works when no exact match is found.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_CaseInsensitiveFallback_ReturnsEntity()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("MyNote.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act – path differs in casing
+		IVaultEntity? result = router.RouteTo("mynote");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("MyNote.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that the routing table is rebuilt when the vault raises an update event
+	/// for an entity addition.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_AfterVaultUpdate_ReflectsNewNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouter router = new(vault);
+
+		// Router is built before the note exists – should return null.
+		Assert.Null(router.RouteTo("new-note"));
+
+		// Act – add a note after the router was created.
+		await vault.WriteNoteAsync("new-note.md", Stream.Null);
+
+		// Assert – the router should pick up the new note after the vault update event.
+		IVaultEntity? result = router.RouteTo("new-note");
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+	}
+
+	/// <summary>
+	/// Tests that adding multiple notes are all registered in the routing table.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_MultipleNotes_AllRouteable()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("alpha.md", Stream.Null);
+		await vault.WriteNoteAsync("beta.md", Stream.Null);
+		await vault.WriteNoteAsync("gamma.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act & Assert
+		Assert.NotNull(router.RouteTo("alpha"));
+		Assert.NotNull(router.RouteTo("beta"));
+		Assert.NotNull(router.RouteTo("gamma"));
+	}
+
+	/// <summary>
+	/// Tests that routing to a note path that still has ".md" extension returns null,
+	/// since the routing table strips ".md" from note paths.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_NotePathWithExtension_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("page.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act – path still has ".md"
+		IVaultEntity? result = router.RouteTo("page.md");
+
+		// Assert – should be null because ".md" is stripped from routing table keys
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that a note with content can be read through the vault after routing.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_NoteWithContent_ContentReadable()
+	{
+		// Arrange
+		const string content = "# Hello World";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("readme.md", Encoding.UTF8.GetBytes(content));
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("readme");
+
+		// Assert
+		Assert.NotNull(result);
+		IVaultNote note = Assert.IsAssignableFrom<IVaultNote>(result);
+		string readContent = await note.ReadDocumentAsync(TestContext.Current.CancellationToken);
+		Assert.Equal(content, readContent);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
@@ -30,7 +30,8 @@ public static class VaultNavigationHelpers
 		// Does it have a front matter? Does it have the "moltenobsidian:index:enabled" key? Is it set to false?
 		if (await note.ReadDocumentAsync() is { Frontmatter: { } frontmatter }
 			&& frontmatter.TryGetValue("moltenobsidian:index:enabled", out object? value)
-			&& value is false or "false")
+			&& (value is false
+				|| value is string stringValue && stringValue.Equals("false", StringComparison.OrdinalIgnoreCase)))
 		{
 			// The index note file was unmarked at file level.
 			return null;

--- a/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
@@ -19,8 +19,8 @@ public static class VaultNavigationHelpers
 		// Find an index note file in the folder.
 		if (folder.GetNotes(SearchOption.TopDirectoryOnly)
 			.FirstOrDefault(static n
-				=> n.Key.Equals("README.md", StringComparison.OrdinalIgnoreCase)
-				|| n.Key.Equals("index.md", StringComparison.OrdinalIgnoreCase)) 
+				=> n.Value.Name.Equals("README.md", StringComparison.OrdinalIgnoreCase)
+				|| n.Value.Name.Equals("index.md", StringComparison.OrdinalIgnoreCase)) 
 			is not { Value: { } note })
 		{
 			// No index note file found.
@@ -30,7 +30,7 @@ public static class VaultNavigationHelpers
 		// Does it have a front matter? Does it have the "moltenobsidian:index:enabled" key? Is it set to false?
 		if (await note.ReadDocumentAsync() is { Frontmatter: { } frontmatter }
 			&& frontmatter.TryGetValue("moltenobsidian:index:enabled", out object? value)
-			&& value is false)
+			&& value is false or "false")
 		{
 			// The index note file was unmarked at file level.
 			return null;

--- a/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
+++ b/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
@@ -11,13 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.v3" Version="3.2.0" />
-        <PackageReference Include="xunit.v3.runner.msbuild" Version="3.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.v3.runner.msbuild" Version="3.2.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Nodsoft.MoltenObsidian.slnx
+++ b/Nodsoft.MoltenObsidian.slnx
@@ -1,6 +1,7 @@
 ﻿<Solution>
 	<Project Path="Nodsoft.MoltenObsidian.Blazor\Nodsoft.MoltenObsidian.Blazor.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian.Manifest\Nodsoft.MoltenObsidian.Manifest.csproj" />
+	<Project Path="Nodsoft.MoltenObsidian.Blazor.Tests\Nodsoft.MoltenObsidian.Blazor.Tests.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian.Tests\Nodsoft.MoltenObsidian.Tests.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian.Tool\Nodsoft.MoltenObsidian.Tool.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian\Nodsoft.MoltenObsidian.csproj" />


### PR DESCRIPTION
Added tests for Blazor components left untested in `Nodsoft.MoltenObsidian.Blazor`. 

_Based on [Copilot's work](https://github.com/Nodsoft/MoltenObsidian/tasks/ff704621-0f0b-4d34-9d9d-b377bad021c3) and recomposed for commit atomicity._