### PR TITLE
Add Blazor tests, fix index note, update deps

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,6 +54,9 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>Nodsoft.MoltenObsidian.Tests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Nodsoft.MoltenObsidian.Blazor.Tests</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 	
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(PackAsTool) != 'true'">
-		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All"/>
+		<PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2" PrivateAssets="All" />
 	</ItemGroup>
 	
 	<ItemGroup Label="PackageInfoFiles">

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultDisplayTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultDisplayTests.cs
@@ -1,0 +1,286 @@
+using System.Text;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Nodsoft.MoltenObsidian.Blazor.Services;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Components;
+
+/// <summary>
+/// Provides tests for the <see cref="ObsidianVaultDisplay"/> Razor component.
+/// </summary>
+/// <seealso cref="ObsidianVaultDisplay"/>
+public sealed class ObsidianVaultDisplayTests : IDisposable
+{
+	private readonly BunitContext _ctx;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ObsidianVaultDisplayTests"/> class.
+	/// </summary>
+	public ObsidianVaultDisplayTests()
+	{
+		_ctx = new BunitContext();
+
+		// Use loose JSInterop mode so that eval() calls in OnAfterRenderAsync do not throw.
+		_ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+		// Register the required VaultRouterFactory service.
+		_ctx.Services.AddSingleton<VaultRouterFactory>();
+	}
+
+	/// <inheritdoc/>
+	public void Dispose() => _ctx.Dispose();
+
+	/// <summary>
+	/// Renders the <see cref="ObsidianVaultDisplay"/> component and returns it.
+	/// </summary>
+	private IRenderedComponent<ObsidianVaultDisplay> RenderDisplay(
+		InMemoryVault vault,
+		string currentPath = "/",
+		string basePath = "/",
+		ObsidianVaultDisplayOptions? options = null)
+		=> _ctx.Render<ObsidianVaultDisplay>(p => p
+			.Add(c => c.Vault, vault)
+			.Add(c => c.CurrentPath, currentPath)
+			.Add(c => c.BasePath, basePath)
+			.Add(c => c.Options, options ?? new ObsidianVaultDisplayOptions()));
+
+	/// <summary>
+	/// Tests that navigating to the vault root (empty path) renders the vault root template
+	/// when there is no index note.
+	/// </summary>
+	[Fact]
+	public async Task Render_RootPathNoIndex_RendersVaultRootTemplate()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("some-note.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/");
+
+		// Assert – the default FoundVaultRoot template renders a <nav> with the vault name
+		AngleSharp.Dom.IElement nav = cut.Find("nav");
+		Assert.Contains("TestVault", nav.GetAttribute("name") ?? string.Empty);
+	}
+
+	/// <summary>
+	/// Tests that navigating to the vault root renders the index note template
+	/// when an index note (README.md) is present.
+	/// </summary>
+	[Fact]
+	public async Task Render_RootPathWithIndexNote_RendersFoundIndexNoteTemplate()
+	{
+		// Arrange
+		const string content = "# Welcome";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/");
+
+		// Assert – FoundIndexNote template renders an <article> element
+		cut.Find("article");
+	}
+
+	/// <summary>
+	/// Tests that navigating to an existing note renders the found-note template.
+	/// </summary>
+	[Fact]
+	public async Task Render_NotePath_RendersFoundNoteTemplate()
+	{
+		// Arrange
+		const string content = "# My Note";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("my-note.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "my-note");
+
+		// Assert – the default FoundNote template renders an <article> element
+		AngleSharp.Dom.IElement article = cut.Find("article");
+		Assert.Equal("my-note.md", article.GetAttribute("name"));
+	}
+
+	/// <summary>
+	/// Tests that navigating to a folder path without an index note renders the found-folder template.
+	/// </summary>
+	[Fact]
+	public async Task Render_FolderPathNoIndex_RendersFoundFolderTemplate()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "section");
+
+		// Assert – the default FoundFolder template renders a <nav> element with folder name
+		AngleSharp.Dom.IElement nav = cut.Find("nav");
+		Assert.Equal("section", nav.GetAttribute("name"));
+	}
+
+	/// <summary>
+	/// Tests that navigating to a folder that has an index note renders the found-index-note template.
+	/// </summary>
+	[Fact]
+	public async Task Render_FolderPathWithIndexNote_RendersFoundIndexNoteTemplate()
+	{
+		// Arrange
+		const string content = "# Section Index";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/index.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "section");
+
+		// Assert – FoundIndexNote template renders an <article class="moltenobsidian-index-note"> element
+		cut.Find("article.moltenobsidian-index-note");
+	}
+
+	/// <summary>
+	/// Tests that navigating to a non-existent path renders the not-found template.
+	/// </summary>
+	[Fact]
+	public void Render_NonExistentPath_RendersNotFoundTemplate()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "does-not-exist");
+
+		// Assert – the default NotFound template renders a <div> with a "No result." heading
+		AngleSharp.Dom.IElement heading = cut.Find("h1");
+		Assert.Equal("No result.", heading.TextContent);
+	}
+
+	/// <summary>
+	/// Tests that a custom <see cref="ObsidianVaultDisplay.NotFound"/> render fragment is invoked
+	/// when the path does not match any entity.
+	/// </summary>
+	[Fact]
+	public void Render_CustomNotFoundFragment_IsRendered()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		RenderFragment<Templates.NotFound.NotFoundRenderContext> customNotFound =
+			ctx => builder =>
+			{
+				builder.OpenElement(0, "section");
+				builder.AddAttribute(1, "id", "custom-not-found");
+				builder.CloseElement();
+			};
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = _ctx.Render<ObsidianVaultDisplay>(p => p
+			.Add(c => c.Vault, vault)
+			.Add(c => c.CurrentPath, "missing")
+			.Add(c => c.BasePath, "/")
+			.Add(c => c.NotFound, customNotFound));
+
+		// Assert – the custom element is rendered (confirming custom fragment is used)
+		cut.Find("section#custom-not-found");
+	}
+
+	/// <summary>
+	/// Tests that a custom <see cref="ObsidianVaultDisplay.FoundNote"/> render fragment is invoked
+	/// when a note is found.
+	/// </summary>
+	[Fact]
+	public async Task Render_CustomFoundNoteFragment_IsRendered()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("doc.md", Stream.Null);
+
+		RenderFragment<Templates.FoundNote.FoundNoteRenderContext> customFoundNote =
+			ctx => builder =>
+			{
+				builder.OpenElement(0, "section");
+				builder.AddAttribute(1, "id", "custom-note");
+				builder.AddContent(2, ctx.Note.Name);
+				builder.CloseElement();
+			};
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = _ctx.Render<ObsidianVaultDisplay>(p => p
+			.Add(c => c.Vault, vault)
+			.Add(c => c.CurrentPath, "doc")
+			.Add(c => c.BasePath, "/")
+			.Add(c => c.FoundNote, customFoundNote));
+
+		// Assert
+		AngleSharp.Dom.IElement section = cut.Find("section#custom-note");
+		Assert.Equal("doc.md", section.TextContent);
+	}
+
+	/// <summary>
+	/// Tests that with <see cref="ObsidianVaultDisplayOptions.DisplayIndexNoteNavigation"/> disabled,
+	/// the index note template does not render the folder navigation tree.
+	/// </summary>
+	[Fact]
+	public async Task Render_IndexNoteNavigationDisabled_OmitsFolderNav()
+	{
+		// Arrange
+		const string content = "# Root";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+		await vault.WriteNoteAsync("other.md", Stream.Null);
+
+		ObsidianVaultDisplayOptions options = new() { DisplayIndexNoteNavigation = false };
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/", options: options);
+
+		// Assert – the folder nav should not be present
+		Assert.Throws<ElementNotFoundException>(
+			() => cut.Find("nav.moltenobsidian-folder-nav")
+		);
+	}
+
+	/// <summary>
+	/// Tests that with <see cref="ObsidianVaultDisplayOptions.DisplayIndexNoteNavigation"/> enabled,
+	/// the index note template also renders the folder navigation.
+	/// </summary>
+	[Fact]
+	public async Task Render_IndexNoteNavigationEnabled_IncludesFolderNav()
+	{
+		// Arrange
+		const string content = "# Root";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+		await vault.WriteNoteAsync("other.md", Stream.Null);
+
+		ObsidianVaultDisplayOptions options = new() { DisplayIndexNoteNavigation = true };
+
+		// Act
+		IRenderedComponent<ObsidianVaultDisplay> cut = RenderDisplay(vault, currentPath: "/", options: options);
+
+		// Assert – folder nav is rendered
+		cut.Find("nav.moltenobsidian-folder-nav");
+	}
+
+	/// <summary>
+	/// Tests that the display throws <see cref="InvalidOperationException"/> when no router is available.
+	/// </summary>
+	[Fact]
+	public void Render_WithoutRouterFactory_ThrowsInvalidOperationException()
+	{
+		// Arrange – no VaultRouterFactory registered, and no Router set
+		using BunitContext ctx = new();
+		ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+		InMemoryVault vault = new("TestVault");
+
+		// Act & Assert
+		Assert.Throws<InvalidOperationException>(() =>
+			ctx.Render<ObsidianVaultDisplay>(p => p
+				.Add(c => c.Vault, vault)
+				.Add(c => c.CurrentPath, "doc")
+				.Add(c => c.BasePath, "/"))
+		);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultDisplayTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultDisplayTests.cs
@@ -1,9 +1,7 @@
 using System.Text;
 using Bunit;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
 using Nodsoft.MoltenObsidian.Blazor.Services;
-using Nodsoft.MoltenObsidian.Vault;
 using Nodsoft.MoltenObsidian.Vaults.InMemory;
 
 namespace Nodsoft.MoltenObsidian.Blazor.Tests.Components;

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultNavigationTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultNavigationTests.cs
@@ -1,0 +1,212 @@
+using Bunit;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Components;
+
+/// <summary>
+/// Provides tests for the <see cref="ObsidianVaultNavigation"/> Razor component.
+/// </summary>
+/// <seealso cref="ObsidianVaultNavigation"/>
+public sealed class ObsidianVaultNavigationTests : IDisposable
+{
+	private readonly BunitContext _ctx;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ObsidianVaultNavigationTests"/> class.
+	/// </summary>
+	public ObsidianVaultNavigationTests()
+	{
+		_ctx = new BunitContext();
+	}
+
+	/// <inheritdoc/>
+	public void Dispose() => _ctx.Dispose();
+
+	/// <summary>
+	/// Tests that the navigation component renders a &lt;nav&gt; element for an empty vault.
+	/// </summary>
+	[Fact]
+	public void Render_EmptyVault_RendersNavElement()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – a <nav> element must be present at the root
+		cut.Find("nav");
+	}
+
+	/// <summary>
+	/// Tests that notes in the root of the vault are rendered as anchor links.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithRootNote_RendersNoteLink()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("my-note.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – a link to "my-note" (without .md) must be present
+		AngleSharp.Dom.IElement link = cut.Find("a[href='my-note']");
+		Assert.Equal("my-note", link.TextContent);
+	}
+
+	/// <summary>
+	/// Tests that multiple notes are all rendered as links.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithMultipleNotes_RendersAllNoteLinks()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("alpha.md", Stream.Null);
+		await vault.WriteNoteAsync("beta.md", Stream.Null);
+		await vault.WriteNoteAsync("gamma.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert
+		cut.Find("a[href='alpha']");
+		cut.Find("a[href='beta']");
+		cut.Find("a[href='gamma']");
+	}
+
+	/// <summary>
+	/// Tests that a subfolder is rendered inside a wrapping &lt;div&gt; element.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithSubfolder_RendersSubfolderDiv()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – a nested note link for "section/page" must be present
+		cut.Find("a[href='section/page']");
+	}
+
+	/// <summary>
+	/// Tests that the ".obsidian" system folder is hidden from the navigation tree.
+	/// </summary>
+	[Fact]
+	public async Task Render_ObsidianSystemFolder_IsHidden()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync(".obsidian/config.md", Stream.Null);
+		await vault.WriteNoteAsync("visible-note.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – the ".obsidian" folder link must not appear
+		Assert.Throws<ElementNotFoundException>(
+			() => cut.Find("a[href='.obsidian/']")
+		);
+
+		// But the visible note must still appear
+		cut.Find("a[href='visible-note']");
+	}
+
+	/// <summary>
+	/// Tests that a subfolder with an index note is rendered as a link (with trailing slash).
+	/// </summary>
+	[Fact]
+	public async Task Render_SubfolderWithIndexNote_RendersFolderAsLink()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/index.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – the folder should have a link ending with "/"
+		cut.Find("a[href='section/']");
+	}
+
+	/// <summary>
+	/// Tests that a subfolder without an index note is rendered as a non-link div.
+	/// </summary>
+	[Fact]
+	public async Task Render_SubfolderWithoutIndexNote_RendersFolderAsDiv()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+		);
+
+		// Assert – the folder should NOT have a direct link (no <a> for the folder itself)
+		Assert.Throws<ElementNotFoundException>(
+			() => cut.Find("a[href='section/']")
+		);
+	}
+
+	/// <summary>
+	/// Tests that custom navigation attributes are applied to the &lt;nav&gt; element.
+	/// </summary>
+	[Fact]
+	public void Render_WithCustomNavigationAttributes_AppliesAttributes()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+				.Add(c => c.NavigationAttributes, _ => new() { ["class"] = "my-nav", ["id"] = "sidebar" })
+		);
+
+		// Assert
+		AngleSharp.Dom.IElement nav = cut.Find("nav");
+		Assert.Equal("my-nav", nav.GetAttribute("class"));
+		Assert.Equal("sidebar", nav.GetAttribute("id"));
+	}
+
+	/// <summary>
+	/// Tests that custom note attributes are applied to the note link elements.
+	/// </summary>
+	[Fact]
+	public async Task Render_WithCustomNoteAttributes_AppliesAttributesToLinks()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("page.md", Stream.Null);
+
+		// Act
+		IRenderedComponent<ObsidianVaultNavigation> cut = _ctx.Render<ObsidianVaultNavigation>(
+			p => p.Add(c => c.Vault, vault)
+				.Add(c => c.NoteAttributes, _ => new() { ["class"] = "note-link" })
+		);
+
+		// Assert
+		AngleSharp.Dom.IElement link = cut.Find("a[href='page']");
+		Assert.Equal("note-link", link.GetAttribute("class"));
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultNavigationTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Components/ObsidianVaultNavigationTests.cs
@@ -1,5 +1,4 @@
 using Bunit;
-using Nodsoft.MoltenObsidian.Vault;
 using Nodsoft.MoltenObsidian.Vaults.InMemory;
 
 namespace Nodsoft.MoltenObsidian.Blazor.Tests.Components;

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultComponentHelpersTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultComponentHelpersTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.AspNetCore.Components;
+using Nodsoft.MoltenObsidian.Blazor.Helpers;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Helpers;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultComponentHelpers"/> class.
+/// </summary>
+/// <seealso cref="VaultComponentHelpers"/>
+public sealed class VaultComponentHelpersTests
+{
+	/// <summary>
+	/// A fake component with a route that has a catch-all slug segment.
+	/// </summary>
+	[Route("/vault/{*slug}")]
+	private sealed class ComponentWithSlugRoute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// A fake component with a simple route that has no trailing slug.
+	/// </summary>
+	[Route("/docs")]
+	private sealed class ComponentWithSimpleRoute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// A fake component with a nested route that has a catch-all slug segment.
+	/// </summary>
+	[Route("/content/section/{*slug}")]
+	private sealed class ComponentWithNestedSlugRoute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// A fake component with no <see cref="RouteAttribute"/>.
+	/// </summary>
+	private sealed class ComponentWithoutRouteAttribute : IComponent
+	{
+		public void Attach(RenderHandle renderHandle) { }
+		public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Tests that a component with a slug segment at the end has the slug stripped,
+	/// returning just the base path with a trailing slash.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithSlugRoute_ReturnsBasePath()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSlugRoute>();
+
+		// Assert
+		Assert.Equal("/vault/", basePath);
+	}
+
+	/// <summary>
+	/// Tests that a component with a simple route (no slug) returns the route with a trailing slash appended.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithSimpleRoute_ReturnsRouteWithTrailingSlash()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSimpleRoute>();
+
+		// Assert
+		Assert.Equal("/docs/", basePath);
+	}
+
+	/// <summary>
+	/// Tests that a component with a nested slug route returns the correct base path.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithNestedSlugRoute_ReturnsNestedBasePath()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithNestedSlugRoute>();
+
+		// Assert
+		Assert.Equal("/content/section/", basePath);
+	}
+
+	/// <summary>
+	/// Tests that calling the method twice for the same component type returns the same value (caching).
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_SameComponentType_ReturnsCachedResult()
+	{
+		// Act
+		string first = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSlugRoute>();
+		string second = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSlugRoute>();
+
+		// Assert
+		Assert.Equal(first, second);
+	}
+
+	/// <summary>
+	/// Tests that a component without a <see cref="RouteAttribute"/> throws <see cref="ArgumentException"/>.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ComponentWithoutRouteAttribute_ThrowsArgumentException()
+	{
+		// Act & Assert
+		Assert.Throws<ArgumentException>(
+			() => VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithoutRouteAttribute>()
+		);
+	}
+
+	/// <summary>
+	/// Tests that the base path always ends with a trailing slash.
+	/// </summary>
+	[Fact]
+	public void GetCallingBaseVaultPath_ResultAlwaysHasTrailingSlash()
+	{
+		// Act
+		string basePath = VaultComponentHelpers.GetCallingBaseVaultPath<ComponentWithSimpleRoute>();
+
+		// Assert
+		Assert.EndsWith("/", basePath);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultNavigationHelpersTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Helpers/VaultNavigationHelpersTests.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using Nodsoft.MoltenObsidian.Blazor.Helpers;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Helpers;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultNavigationHelpers"/> class.
+/// </summary>
+/// <seealso cref="VaultNavigationHelpers"/>
+public sealed class VaultNavigationHelpersTests
+{
+	/// <summary>
+	/// Tests that a folder containing a "README.md" file returns it as the index note.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_WithReadmeMd_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("README.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that a folder containing an "index.md" file returns it as the index note.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_WithIndexMd_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("index.md", Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("index.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that "README.md" detection is case-insensitive.
+	/// </summary>
+	[Theory]
+	[InlineData("readme.md")]
+	[InlineData("Readme.md")]
+	[InlineData("README.MD")]
+	public async Task GetIndexNoteAsync_ReadmeMdCaseInsensitive_ReturnsNote(string filename)
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync(filename, Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+	}
+
+	/// <summary>
+	/// Tests that "index.md" detection is case-insensitive.
+	/// </summary>
+	[Theory]
+	[InlineData("index.md")]
+	[InlineData("Index.md")]
+	[InlineData("INDEX.MD")]
+	public async Task GetIndexNoteAsync_IndexMdCaseInsensitive_ReturnsNote(string filename)
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync(filename, Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+	}
+
+	/// <summary>
+	/// Tests that a folder with no index note returns null.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_NoIndexNote_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("other-note.md", Stream.Null);
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that an empty folder returns null.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_EmptyFolder_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that an index note with frontmatter setting "moltenobsidian:index:enabled" to false
+	/// is not returned as the index note.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_DisabledByFrontmatter_ReturnsNull()
+	{
+		// Arrange
+		const string content = """
+			---
+			moltenobsidian:index:enabled: false
+			---
+
+			# Hidden Index
+			""";
+
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that an index note with frontmatter not setting "moltenobsidian:index:enabled"
+	/// is returned normally.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_FrontmatterWithoutIndexKey_ReturnsNote()
+	{
+		// Arrange
+		const string content = """
+			---
+			title: Home
+			---
+
+			# Home
+			""";
+
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("README.md", Encoding.UTF8.GetBytes(content));
+
+		// Act
+		IVaultNote? result = await vault.Root.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+	}
+
+	/// <summary>
+	/// Tests that an index note inside a subfolder is also correctly detected.
+	/// </summary>
+	[Fact]
+	public async Task GetIndexNoteAsync_IndexNoteInSubfolder_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("section/README.md", Stream.Null);
+
+		IVaultFolder? subfolder = (vault as IVault).GetFolder("section");
+
+		// Act
+		IVaultNote? result = await subfolder!.GetIndexNoteAsync();
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("section/README.md", result.Path);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Nodsoft.MoltenObsidian.Blazor.Tests.csproj
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Nodsoft.MoltenObsidian.Blazor.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="bunit" Version="2.7.2" />
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.v3.runner.msbuild" Version="3.2.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Nodsoft.MoltenObsidian.Blazor\Nodsoft.MoltenObsidian.Blazor.csproj" />
+        <ProjectReference Include="..\Vaults\Nodsoft.MoltenObsidian.Vaults.InMemory\Nodsoft.MoltenObsidian.Vaults.InMemory.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/ObsidianDependencyInjectionExtensionsTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/ObsidianDependencyInjectionExtensionsTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nodsoft.MoltenObsidian.Blazor.Services;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests;
+
+/// <summary>
+/// Provides tests for the <see cref="ObsidianDependencyInjectionExtensions"/> class.
+/// </summary>
+/// <seealso cref="ObsidianDependencyInjectionExtensions"/>
+public sealed class ObsidianDependencyInjectionExtensionsTests
+{
+	/// <summary>
+	/// Tests that <see cref="ObsidianDependencyInjectionExtensions.AddMoltenObsidianBlazorIntegration"/>
+	/// registers <see cref="VaultRouterFactory"/> as a singleton service.
+	/// </summary>
+	[Fact]
+	public void AddMoltenObsidianBlazorIntegration_RegistersVaultRouterFactory()
+	{
+		// Arrange
+		ServiceCollection services = new();
+
+		// Act
+		services.AddMoltenObsidianBlazorIntegration();
+		ServiceProvider provider = services.BuildServiceProvider();
+
+		// Assert
+		VaultRouterFactory? factory = provider.GetService<VaultRouterFactory>();
+		Assert.NotNull(factory);
+	}
+
+	/// <summary>
+	/// Tests that <see cref="VaultRouterFactory"/> is registered as a singleton
+	/// (the same instance is returned on successive resolutions).
+	/// </summary>
+	[Fact]
+	public void AddMoltenObsidianBlazorIntegration_VaultRouterFactory_IsSingleton()
+	{
+		// Arrange
+		ServiceCollection services = new();
+		services.AddMoltenObsidianBlazorIntegration();
+		ServiceProvider provider = services.BuildServiceProvider();
+
+		// Act
+		VaultRouterFactory first = provider.GetRequiredService<VaultRouterFactory>();
+		VaultRouterFactory second = provider.GetRequiredService<VaultRouterFactory>();
+
+		// Assert – singleton: same instance every time
+		Assert.Same(first, second);
+	}
+
+	/// <summary>
+	/// Tests that <see cref="ObsidianDependencyInjectionExtensions.AddMoltenObsidianBlazorIntegration"/>
+	/// returns the same <see cref="IServiceCollection"/> instance to allow call chaining.
+	/// </summary>
+	[Fact]
+	public void AddMoltenObsidianBlazorIntegration_ReturnsServiceCollection()
+	{
+		// Arrange
+		ServiceCollection services = new();
+
+		// Act
+		IServiceCollection result = services.AddMoltenObsidianBlazorIntegration();
+
+		// Assert
+		Assert.Same(services, result);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/ObsidianDependencyInjectionExtensionsTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/ObsidianDependencyInjectionExtensionsTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Nodsoft.MoltenObsidian.Blazor.Services;
 
 namespace Nodsoft.MoltenObsidian.Blazor.Tests;

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterFactoryTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterFactoryTests.cs
@@ -1,0 +1,86 @@
+using Nodsoft.MoltenObsidian.Blazor.Services;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Services;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultRouterFactory"/> class.
+/// </summary>
+/// <seealso cref="VaultRouterFactory"/>
+public sealed class VaultRouterFactoryTests
+{
+	/// <summary>
+	/// Tests that requesting a router for the same vault instance returns the same cached router.
+	/// </summary>
+	[Fact]
+	public void GetRouter_SameVaultInstance_ReturnsCachedRouter()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter first = factory.GetRouter(vault);
+		VaultRouter second = factory.GetRouter(vault);
+
+		// Assert – must be the exact same instance
+		Assert.Same(first, second);
+	}
+
+	/// <summary>
+	/// Tests that requesting routers for two distinct vault instances returns different routers.
+	/// </summary>
+	[Fact]
+	public void GetRouter_DifferentVaultInstances_ReturnsDifferentRouters()
+	{
+		// Arrange
+		InMemoryVault vault1 = new("Vault1");
+		InMemoryVault vault2 = new("Vault2");
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter router1 = factory.GetRouter(vault1);
+		VaultRouter router2 = factory.GetRouter(vault2);
+
+		// Assert – must be different instances
+		Assert.NotSame(router1, router2);
+	}
+
+	/// <summary>
+	/// Tests that the router returned by the factory actually routes to the vault's contents.
+	/// </summary>
+	[Fact]
+	public async Task GetRouter_RouterRoutesToVaultContents()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("doc.md", Stream.Null);
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter router = factory.GetRouter(vault);
+		IVaultEntity? result = router.RouteTo("doc");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+	}
+
+	/// <summary>
+	/// Tests that the factory creates a new router for a previously unseen vault.
+	/// </summary>
+	[Fact]
+	public void GetRouter_NewVault_ReturnsNewRouter()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouterFactory factory = new();
+
+		// Act
+		VaultRouter router = factory.GetRouter(vault);
+
+		// Assert
+		Assert.NotNull(router);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
@@ -153,7 +153,7 @@ public sealed class VaultRouterTests
 	/// Tests that adding multiple notes are all registered in the routing table.
 	/// </summary>
 	[Fact]
-	public async Task RouteTo_MultipleNotes_AllRouteable()
+	public async Task RouteTo_MultipleNotes_AllRoutable()
 	{
 		// Arrange
 		InMemoryVault vault = new("TestVault");

--- a/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
+++ b/Nodsoft.MoltenObsidian.Blazor.Tests/Services/VaultRouterTests.cs
@@ -1,0 +1,211 @@
+using System.Text;
+using Nodsoft.MoltenObsidian.Blazor.Services;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.InMemory;
+
+namespace Nodsoft.MoltenObsidian.Blazor.Tests.Services;
+
+/// <summary>
+/// Provides tests for the <see cref="VaultRouter"/> class.
+/// </summary>
+/// <seealso cref="VaultRouter"/>
+public sealed class VaultRouterTests
+{
+	/// <summary>
+	/// Tests that routing to an existing folder returns the correct folder.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_ExistingFolder_ReturnsFolder()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.CreateFolderAsync("notes");
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("notes");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultFolder>(result);
+		Assert.Equal("notes", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that routing to an existing note (without ".md" extension) returns the correct note.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_ExistingNote_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("hello.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("hello");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+		Assert.Equal("hello.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that routing to an existing note in a subfolder returns the correct note.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_NoteInSubfolder_ReturnsNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("notes/page.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("notes/page");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+		Assert.Equal("notes/page.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that routing to a path that doesn't exist returns null.
+	/// </summary>
+	[Fact]
+	public void RouteTo_NonExistentPath_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("does-not-exist");
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that case-sensitive routing is preferred when an exact match is found.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_CaseSensitiveMatch_ReturnsEntity()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("MyNote.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("MyNote");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("MyNote.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that case-insensitive fallback routing works when no exact match is found.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_CaseInsensitiveFallback_ReturnsEntity()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("MyNote.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act – path differs in casing
+		IVaultEntity? result = router.RouteTo("mynote");
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal("MyNote.md", result.Path);
+	}
+
+	/// <summary>
+	/// Tests that the routing table is rebuilt when the vault raises an update event
+	/// for an entity addition.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_AfterVaultUpdate_ReflectsNewNote()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		VaultRouter router = new(vault);
+
+		// Router is built before the note exists – should return null.
+		Assert.Null(router.RouteTo("new-note"));
+
+		// Act – add a note after the router was created.
+		await vault.WriteNoteAsync("new-note.md", Stream.Null);
+
+		// Assert – the router should pick up the new note after the vault update event.
+		IVaultEntity? result = router.RouteTo("new-note");
+		Assert.NotNull(result);
+		Assert.IsAssignableFrom<IVaultNote>(result);
+	}
+
+	/// <summary>
+	/// Tests that adding multiple notes are all registered in the routing table.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_MultipleNotes_AllRouteable()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("alpha.md", Stream.Null);
+		await vault.WriteNoteAsync("beta.md", Stream.Null);
+		await vault.WriteNoteAsync("gamma.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act & Assert
+		Assert.NotNull(router.RouteTo("alpha"));
+		Assert.NotNull(router.RouteTo("beta"));
+		Assert.NotNull(router.RouteTo("gamma"));
+	}
+
+	/// <summary>
+	/// Tests that routing to a note path that still has ".md" extension returns null,
+	/// since the routing table strips ".md" from note paths.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_NotePathWithExtension_ReturnsNull()
+	{
+		// Arrange
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("page.md", Stream.Null);
+		VaultRouter router = new(vault);
+
+		// Act – path still has ".md"
+		IVaultEntity? result = router.RouteTo("page.md");
+
+		// Assert – should be null because ".md" is stripped from routing table keys
+		Assert.Null(result);
+	}
+
+	/// <summary>
+	/// Tests that a note with content can be read through the vault after routing.
+	/// </summary>
+	[Fact]
+	public async Task RouteTo_NoteWithContent_ContentReadable()
+	{
+		// Arrange
+		const string content = "# Hello World";
+		InMemoryVault vault = new("TestVault");
+		await vault.WriteNoteAsync("readme.md", Encoding.UTF8.GetBytes(content));
+		VaultRouter router = new(vault);
+
+		// Act
+		IVaultEntity? result = router.RouteTo("readme");
+
+		// Assert
+		Assert.NotNull(result);
+		IVaultNote note = Assert.IsAssignableFrom<IVaultNote>(result);
+		string readContent = await note.ReadDocumentAsync(TestContext.Current.CancellationToken);
+		Assert.Equal(content, readContent);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Nodsoft.MoltenObsidian.Vault;
+﻿using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Blazor.Helpers;
 

--- a/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
@@ -30,7 +30,8 @@ public static class VaultNavigationHelpers
 		// Does it have a front matter? Does it have the "moltenobsidian:index:enabled" key? Is it set to false?
 		if (await note.ReadDocumentAsync() is { Frontmatter: { } frontmatter }
 			&& frontmatter.TryGetValue("moltenobsidian:index:enabled", out object? value)
-			&& value is false or "false")
+			&& (value is false
+				|| value is string stringValue && stringValue.Equals("false", StringComparison.OrdinalIgnoreCase)))
 		{
 			// The index note file was unmarked at file level.
 			return null;

--- a/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/Helpers/VaultNavigationHelpers.cs
@@ -19,8 +19,8 @@ public static class VaultNavigationHelpers
 		// Find an index note file in the folder.
 		if (folder.GetNotes(SearchOption.TopDirectoryOnly)
 			.FirstOrDefault(static n
-				=> n.Key.Equals("README.md", StringComparison.OrdinalIgnoreCase)
-				|| n.Key.Equals("index.md", StringComparison.OrdinalIgnoreCase)) 
+				=> n.Value.Name.Equals("README.md", StringComparison.OrdinalIgnoreCase)
+				|| n.Value.Name.Equals("index.md", StringComparison.OrdinalIgnoreCase)) 
 			is not { Value: { } note })
 		{
 			// No index note file found.
@@ -30,7 +30,7 @@ public static class VaultNavigationHelpers
 		// Does it have a front matter? Does it have the "moltenobsidian:index:enabled" key? Is it set to false?
 		if (await note.ReadDocumentAsync() is { Frontmatter: { } frontmatter }
 			&& frontmatter.TryGetValue("moltenobsidian:index:enabled", out object? value)
-			&& value is false)
+			&& value is false or "false")
 		{
 			// The index note file was unmarked at file level.
 			return null;

--- a/Nodsoft.MoltenObsidian.Blazor/Nodsoft.MoltenObsidian.Blazor.csproj
+++ b/Nodsoft.MoltenObsidian.Blazor/Nodsoft.MoltenObsidian.Blazor.csproj
@@ -14,11 +14,11 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.12" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.25" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.5" />
 	</ItemGroup>
 	
 </Project>

--- a/Nodsoft.MoltenObsidian.Blazor/ObsidianDependencyInjectionExtensions.cs
+++ b/Nodsoft.MoltenObsidian.Blazor/ObsidianDependencyInjectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Nodsoft.MoltenObsidian.Blazor.Services;
-using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Blazor;
 

--- a/Nodsoft.MoltenObsidian.Manifest/Nodsoft.MoltenObsidian.Manifest.csproj
+++ b/Nodsoft.MoltenObsidian.Manifest/Nodsoft.MoltenObsidian.Manifest.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="System.Text.Json" Version="10.0.0" />
+		<PackageReference Include="System.Text.Json" Version="10.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Nodsoft.MoltenObsidian.Manifest/VaultManifestGenerator.cs
+++ b/Nodsoft.MoltenObsidian.Manifest/VaultManifestGenerator.cs
@@ -12,8 +12,9 @@ public static class VaultManifestGenerator
 	/// Generates a manifest for the specified vault.
 	/// </summary>
 	/// <param name="vault">The path to the vault.</param>
+	/// <param name="ct">A cancellation token.</param>
 	/// <returns>A <see cref="RemoteVaultManifest"/> instance.</returns>
-	public static async Task<RemoteVaultManifest> GenerateManifestAsync(IVault vault)
+	public static async Task<RemoteVaultManifest> GenerateManifestAsync(IVault vault, CancellationToken ct = default)
 	{
 		List<ManifestFile> files = [];
 
@@ -22,7 +23,7 @@ public static class VaultManifestGenerator
 		{
 			if (file.Name is not RemoteVaultManifest.ManifestFileName)
 			{
-				files.Add(await ExtractManifestInfoAsync(file));
+				files.Add(await ExtractManifestInfoAsync(file, ct));
 			}
 		}
 
@@ -38,8 +39,9 @@ public static class VaultManifestGenerator
 	/// Extracts manifest information from a vault file.
 	/// </summary>
 	/// <param name="file">The file to extract information from.</param>
+	/// <param name="ct">A cancellation token.</param>
 	/// <returns>A <see cref="ManifestFile"/> instance.</returns>
-	private static async Task<ManifestFile> ExtractManifestInfoAsync(IVaultFile file)
+	private static async Task<ManifestFile> ExtractManifestInfoAsync(IVaultFile file, CancellationToken ct)
 	{
 		// Read the file. We'll need it later.
 		await using Stream stream = await file.OpenReadAsync();
@@ -48,22 +50,23 @@ public static class VaultManifestGenerator
 		return new()
 		{
 			Path = file.Path,
-			Hash = await HashDataAsync(stream),
+			Hash = await HashDataAsync(stream, ct),
 			Size = stream.Length,
 			ContentType = Manifest.MimeTypes.GetMimeType(file.Name), // A fuller namespace is required here because of a conflict with the other apparitions of MimeTypes.
-			Metadata = file is IVaultNote note ? (await note.ReadDocumentAsync()).Frontmatter : []
+			Metadata = file is IVaultNote note ? (await note.ReadDocumentAsync(ct: ct)).Frontmatter : []
 		};
 	}
-	
+
 	/// <summary>
 	/// Computes the SHA256 hash of the specified stream.
 	/// </summary>
 	/// <param name="stream">The stream to hash.</param>
+	/// <param name="ct">A cancellation token.</param>
 	/// <returns>The SHA256 hash of the stream.</returns>
-	internal static async ValueTask<string> HashDataAsync(Stream stream)
+	internal static async ValueTask<string> HashDataAsync(Stream stream, CancellationToken ct = default)
 	{
 #if NET7_0_OR_GREATER
-		return Convert.ToBase64String(await SHA256.HashDataAsync(stream));
+		return Convert.ToBase64String(await SHA256.HashDataAsync(stream, ct));
 #else
 		byte[] fileBytes = new byte[stream.Length];
 		int readBytesCount = await stream.ReadAsync(fileBytes);

--- a/Nodsoft.MoltenObsidian.Tests/Core/MarkdownExtensions/ObsidianTagsTests.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Core/MarkdownExtensions/ObsidianTagsTests.cs
@@ -12,7 +12,7 @@ namespace Nodsoft.MoltenObsidian.Tests.Core.MarkdownExtensions;
 /// Provides tests for the Obsidian Tags parser and renderer.
 /// </summary>
 [Collection("ObsidianTags")]
-public class ObsidianTagsTests
+public sealed class ObsidianTagsTests
 {
     private readonly MarkdownPipeline _pipeline;
     
@@ -48,7 +48,7 @@ public class ObsidianTagsTests
     /// <summary>
     /// Tests that a valid tag is correctly parsed and rendered.
     /// </summary>
-    /// <param name="markdown">The markdown to parse.</param>
+    /// <param name="markdown">The Markdown to parse.</param>
     /// <param name="expectedHtml">The expected HTML output.</param>
     [Theory, MemberData(nameof(ValidTags))]
     public void ParseAndRender_Standalone_Nominal(string markdown, string expectedHtml)
@@ -69,7 +69,7 @@ public class ObsidianTagsTests
     /// <summary>
     /// Tests that an invalid tag is correctly parsed and rendered.
     /// </summary>
-    /// <param name="markdown">The markdown to parse.</param>
+    /// <param name="markdown">The Markdown to parse.</param>
     /// <param name="expectedHtml">The expected HTML output.</param>
     [Theory, MemberData(nameof(InvalidTags))]
     public void ParseAndRender_Standalone_Ignored(string markdown, string expectedHtml)
@@ -81,7 +81,7 @@ public class ObsidianTagsTests
     /// <summary>
     /// Tests that a tag is correctly parsed and rendered when it is part of a larger text block.
     /// </summary>
-    /// <param name="markdown">The markdown to parse.</param>
+    /// <param name="markdown">The Markdown to parse.</param>
     /// <param name="expectedHtml">The expected HTML output.</param>
     [Theory, MemberData(nameof(ValidTags))]
     public void ParseAndRender_InTextBlock_Nominal(string markdown, string expectedHtml)
@@ -93,7 +93,7 @@ public class ObsidianTagsTests
     /// <summary>
     /// Tests that an invalid tag is correctly parsed and rendered when it is part of a larger text block.
     /// </summary>
-    /// <param name="markdown">The markdown to parse.</param>
+    /// <param name="markdown">The Markdown to parse.</param>
     /// <param name="expectedHtml">The expected HTML output.</param>
     [Theory, MemberData(nameof(InvalidTags))]
     public void ParseAndRender_InTextBlock_Ignored(string markdown, string expectedHtml)

--- a/Nodsoft.MoltenObsidian.Tests/Core/ObsidianTextTests.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Core/ObsidianTextTests.cs
@@ -170,7 +170,7 @@ public sealed class ObsidianTextTests
     }
     
     /// <summary>
-    /// Tests the string representation of an <see cref="ObsidianText"/> with a markdown string.
+    /// Tests the string representation of an <see cref="ObsidianText"/> with a Markdown string.
     /// </summary>
     [Fact]
     public void ToString_Nominal()
@@ -186,7 +186,7 @@ public sealed class ObsidianTextTests
     }
     
     /// <summary>
-    /// Tests the string representation of an <see cref="ObsidianText"/> with a frontmatter markdown string.
+    /// Tests the string representation of an <see cref="ObsidianText"/> with a frontmatter Markdown string.
     /// </summary>
     [Fact]
     public void ToString_Frontmatter_Nominal()

--- a/Nodsoft.MoltenObsidian.Tests/Manifest/VaultManifestTests.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Manifest/VaultManifestTests.cs
@@ -1,5 +1,4 @@
 using Nodsoft.MoltenObsidian.Manifest;
-using Nodsoft.MoltenObsidian.Tests.Vaults;
 using Nodsoft.MoltenObsidian.Tests.Vaults.FileSystem;
 using Nodsoft.MoltenObsidian.Vaults.FileSystem;
 
@@ -11,7 +10,7 @@ namespace Nodsoft.MoltenObsidian.Tests.Manifest;
 /// Provides tests for the vault manifest system
 /// </summary>
 [Collection("VaultManifest")]
-public class VaultManifestTests : IClassFixture<FileSystemVaultFixture>
+public sealed class VaultManifestTests : IClassFixture<FileSystemVaultFixture>
 {
     private readonly FileSystemVaultFixture _fixture;
 
@@ -34,7 +33,7 @@ public class VaultManifestTests : IClassFixture<FileSystemVaultFixture>
         FileSystemVault vault = _fixture.Vault;
         
         // Act
-        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault);
+        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault, TestContext.Current.CancellationToken);
         
         // Assert
         Assert.NotNull(manifest);
@@ -51,7 +50,7 @@ public class VaultManifestTests : IClassFixture<FileSystemVaultFixture>
         FileSystemVault vault = _fixture.Vault;
         
         // Act
-        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault);
+        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault, TestContext.Current.CancellationToken);
         
         // Assert
         Assert.NotNull(manifest);
@@ -73,7 +72,7 @@ public class VaultManifestTests : IClassFixture<FileSystemVaultFixture>
         FileSystemVault vault = _fixture.Vault;
         
         // Act
-        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault);
+        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault, TestContext.Current.CancellationToken);
         
         // Assert
         Assert.NotNull(manifest);
@@ -97,7 +96,7 @@ public class VaultManifestTests : IClassFixture<FileSystemVaultFixture>
         FileSystemVault vault = _fixture.Vault;
         
         // Act
-        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault);
+        RemoteVaultManifest manifest = await VaultManifestGenerator.GenerateManifestAsync(vault, TestContext.Current.CancellationToken);
         
         // Assert
         Assert.NotNull(manifest);
@@ -106,7 +105,7 @@ public class VaultManifestTests : IClassFixture<FileSystemVaultFixture>
         {
             ManifestFile manifestFile = manifest.Files.FirstOrDefault(mf => mf.Path == f.Key);
             await using Stream stream = await f.Value.OpenReadAsync();
-            string hash = await VaultManifestGenerator.HashDataAsync(stream);
+            string hash = await VaultManifestGenerator.HashDataAsync(stream, TestContext.Current.CancellationToken);
 
             Assert.Equal(hash, manifestFile.Hash);
         });

--- a/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
+++ b/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -31,6 +31,7 @@
       <ProjectReference Include="..\Nodsoft.MoltenObsidian.Manifest\Nodsoft.MoltenObsidian.Manifest.csproj" />
       <ProjectReference Include="..\Nodsoft.MoltenObsidian\Nodsoft.MoltenObsidian.csproj" />
       <ProjectReference Include="..\Vaults\Nodsoft.MoltenObsidian.Vaults.FileSystem\Nodsoft.MoltenObsidian.Vaults.FileSystem.csproj" />
+      <ProjectReference Include="..\Vaults\Nodsoft.MoltenObsidian.Vaults.Http\Nodsoft.MoltenObsidian.Vaults.Http.csproj" />
       <ProjectReference Include="..\Vaults\Nodsoft.MoltenObsidian.Vaults.InMemory\Nodsoft.MoltenObsidian.Vaults.InMemory.csproj" />
     </ItemGroup>
 

--- a/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
+++ b/Nodsoft.MoltenObsidian.Tests/Nodsoft.MoltenObsidian.Tests.csproj
@@ -11,13 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.v3" Version="3.2.0" />
-        <PackageReference Include="xunit.v3.runner.msbuild" Version="3.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.v3.runner.msbuild" Version="3.2.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/FileSystem/FileSystemVaultFixture.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/FileSystem/FileSystemVaultFixture.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using Nodsoft.MoltenObsidian.Vaults.FileSystem;
 
 namespace Nodsoft.MoltenObsidian.Tests.Vaults.FileSystem;
@@ -6,6 +7,7 @@ namespace Nodsoft.MoltenObsidian.Tests.Vaults.FileSystem;
 /// Provides a test fixture for the <see cref="FileSystemVault"/> class.
 /// </summary>
 
+[UsedImplicitly]
 public sealed class FileSystemVaultFixture : IDisposable
 {
     /// <summary>

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/FileSystem/FileSystemVaultTests.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/FileSystem/FileSystemVaultTests.cs
@@ -9,7 +9,7 @@ namespace Nodsoft.MoltenObsidian.Tests.Vaults.FileSystem;
 /// </summary>
 /// <seealso cref="FileSystemVault"/>
 [Collection(nameof(FileSystemVault))]
-public class FileSystemVaultTests
+public sealed class FileSystemVaultTests
 {
     private readonly FileSystemVaultFixture _fixture;
 
@@ -52,6 +52,7 @@ public class FileSystemVaultTests
         DirectoryInfo nonExistentFolder = new("NonExistentFolder");
         
         // Act
+        // ReSharper disable once ConvertToLocalFunction
         Action act = () => FileSystemVault.FromDirectory(nonExistentFolder);
         
         // Assert
@@ -150,7 +151,7 @@ public class FileSystemVaultTests
     }
     
     /// <summary>
-    /// Tests the correct typing of a markdown file as a note.
+    /// Tests the correct typing of a Markdown file as a note.
     /// </summary>
     [Fact]
     public void GetFile_FileIsNote_Nominal()
@@ -179,7 +180,7 @@ public class FileSystemVaultTests
         IVaultNote note = vault.Notes["VeryNiceFolder/Hidden Note.md"];
         
         // Act
-        string content = await note.ReadDocumentAsync();
+        string content = await note.ReadDocumentAsync(ct: TestContext.Current.CancellationToken);
         
         
         
@@ -199,7 +200,7 @@ public class FileSystemVaultTests
         IVaultNote note = vault.Notes["README.md"];
         
         // Act
-        ObsidianText content = await note.ReadDocumentAsync();
+        ObsidianText content = await note.ReadDocumentAsync(ct: TestContext.Current.CancellationToken);
         
         // Assert
         Assert.NotNull(note);

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpRemoteVaultTests.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpRemoteVaultTests.cs
@@ -1,0 +1,177 @@
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.Http;
+using Nodsoft.MoltenObsidian.Vaults.Http.Data;
+
+namespace Nodsoft.MoltenObsidian.Tests.Vaults.Http;
+
+/// <summary>
+/// Provides tests for the <see cref="HttpRemoteVault"/> class.
+/// </summary>
+[Collection(nameof(HttpRemoteVault))]
+public sealed class HttpRemoteVaultTests
+{
+	private readonly HttpVaultServerFixture _fixture;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="HttpRemoteVaultTests" /> class.
+	/// </summary>
+	public HttpRemoteVaultTests(HttpVaultServerFixture fixture)
+	{
+		_fixture = fixture;
+	}
+	
+	/// <summary>
+	/// Tests that the vault can be created.
+	/// </summary>
+	[Fact]
+	public async Task CreateVaultFromManifest_Nominal()
+	{
+		// Arrange
+		// Act
+		IVault vault = await _fixture.CreateHttpRemoteVaultAsync(TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.NotNull(vault);
+		Assert.NotNull(vault.Root);
+		Assert.Equal("TestVault", vault.Root.Name);
+	}
+	
+	/// <summary>
+	/// Tests the retrieval of a file from a <see cref="HttpRemoteVault" />.
+	/// </summary>
+	/// <param name="path">The path of the file to retrieve.</param>
+	[Theory]
+	[InlineData("README.md")]
+	[InlineData("VeryNiceFolder/Hidden Note.md")]
+	public void GetFile_Nominal(string path)
+	{
+		// Arrange
+		IVault vault = _fixture.Vault;
+        
+		// Act
+		IVaultFile? file = vault.Files.GetValueOrDefault(path);
+        
+		// Assert
+		Assert.NotNull(file);
+		Assert.Equal(path, file.Path);
+	}
+	
+	/// <summary>
+	/// Tests the retrieval of a non-existent file from a <see cref="HttpRemoteVault" />.
+	/// </summary>
+	[Fact]
+	public void GetFile_FileDoesNotExist()
+	{
+		// Arrange
+		IVault vault = _fixture.Vault;
+        
+		// Act
+		IVaultFile? file = vault.GetFile("NonExistentFile.txt");
+        
+		// Assert
+		Assert.Null(file);
+	}
+	
+	/// <summary>
+	/// Tests the retrieval of a directory from a <see cref="HttpRemoteVault" />.
+	/// </summary>
+	/// <param name="path">The path of the directory to retrieve.</param>
+	[Theory]
+	[InlineData("VeryNiceFolder")]
+	public void GetDirectory_Nominal(string path)
+	{
+		// Arrange
+		IVault vault = _fixture.Vault;
+        
+		// Act
+		IVaultFolder? folder = vault.GetFolder(path);
+        
+		// Assert
+		Assert.NotNull(folder);
+		Assert.Equal(path, folder.Path);
+	}
+	
+	/// <summary>
+	/// Tests the retrieval of a non-existent directory from a <see cref="HttpRemoteVault" />.
+	/// </summary>
+	[Fact]
+	public void GetDirectory_NonExistent_Nominal()
+	{
+		// Arrange
+		IVault vault = _fixture.Vault;
+        
+		// Act
+		IVaultFolder? folder = vault.GetFolder("NonExistentFolder");
+        
+		// Assert
+		Assert.Null(folder);
+	}
+	
+	/// <summary>
+	/// Tests the correct typing of a markdown file as a note.
+	/// </summary>
+	[Fact]
+	public void GetFile_FileIsNote_Nominal()
+	{
+		// Arrange
+		IVault vault = _fixture.Vault;
+        
+		// Act
+		IVaultFile? file = vault.GetFile("VeryNiceFolder/Hidden Note.md");
+        
+		// Assert
+		Assert.NotNull(file);
+		Assert.Equal("text/markdown", file.ContentType);
+		Assert.IsAssignableFrom<IVaultNote>(file);
+		Assert.IsType<HttpRemoteNote>(file);
+	}
+	
+	/// <summary>
+	/// Tests the content of a note file.
+	/// </summary>
+	[Fact]
+	public async Task GetNoteContent_SimpleNote_Nominal()
+	{
+		// Arrange
+		IVault vault = _fixture.Vault;
+		IVaultNote note = vault.Notes["VeryNiceFolder/Hidden Note.md"];
+        
+		// Act
+		string content = await note.ReadDocumentAsync(TestContext.Current.CancellationToken);
+        
+		// Assert
+		Assert.NotNull(note);
+		Assert.Equal(/*lang=md*/$"This is a hidden note!{Environment.NewLine}Not at all.{Environment.NewLine}It's just in a folder.", content);
+	}
+	
+	/// <summary>
+	/// Tests the HTML conversion of a note, containing tags and internal links.
+	/// </summary>
+	[Fact]
+	public async Task GetNoteContent_ComplexNote_Nominal()
+	{
+		// Arrange
+		IVault vault = _fixture.Vault;
+		IVaultNote note = vault.Notes["README.md"];
+        
+		// Act
+		ObsidianText content = await note.ReadDocumentAsync(TestContext.Current.CancellationToken);
+        
+		// Assert
+		Assert.NotNull(note);
+        
+		Assert.Equal(
+			/*lang=md*/$"# README{Environment.NewLine}{Environment.NewLine}" +
+			$"This is a test vault, meant to be used with the `Nodsoft.MoltenObsidian.Tests` project's test suite.{Environment.NewLine}{Environment.NewLine}" +
+			$"## See also :{Environment.NewLine}{Environment.NewLine}Check out this #cool_tag and #cooler_tag, and my [[Hidden Note]].", 
+			content
+		);
+        
+		Assert.Equal(
+			/*lang=html*/"<h1 id=\"readme\">README</h1>\n<p>This is a test vault, meant to be used with the <code>Nodsoft.MoltenObsidian.Tests</code> project's test suite.</p>\n" +
+			/*lang=html*/"<h2 id=\"see-also\">See also :</h2>\n<p>Check out this <span class=\"tag moltenobsidian-tag\" data-name=\"cool_tag\">cool_tag</span> and <span class=\"tag moltenobsidian-tag\" data-name=\"cooler_tag\">cooler_tag</span>, " +
+			/*lang=html*/"and my <a href=\"VeryNiceFolder/Hidden%20Note\" title=\"Hidden Note\">Hidden Note</a>.</p>\n",
+			content.ToHtml()
+		);
+	}
+}

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpVaultServerFixture.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpVaultServerFixture.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using JetBrains.Annotations;
+using Microsoft.Extensions.FileProviders;
+using Nodsoft.MoltenObsidian.Manifest;
+using Nodsoft.MoltenObsidian.Vault;
+using Nodsoft.MoltenObsidian.Vaults.FileSystem;
+using Nodsoft.MoltenObsidian.Vaults.Http;
+
+namespace Nodsoft.MoltenObsidian.Tests.Vaults.Http;
+
+/// <summary>
+/// Hosts a static HTTP server that serves a MoltenObsidian remote vault (manifest + files).
+/// Shared across all tests in the "HttpVault" collection.
+/// </summary>
+[UsedImplicitly]
+public sealed class HttpVaultServerFixture : IAsyncLifetime
+{
+    /// <summary>
+    /// The directory that the vault is based on.
+    /// </summary>
+    internal DirectoryInfo RootDirectory { get; }
+    
+    /// <summary>
+    /// The base URI of the hosted vault.
+    /// </summary>
+    public Uri BaseUri => new($"http://127.0.0.1:{_port}/");
+    
+    private readonly WebApplication _app;
+    private readonly int _port;
+
+    private HttpClient Client
+    {
+        get => field ?? throw new InvalidOperationException("HttpClient not initialized yet.");
+        set;
+    }
+
+    /// <summary>
+    /// The vault being hosted.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if the vault is accessed before initialization.</exception>
+    public HttpRemoteVault Vault
+    {
+        get => field ?? throw new InvalidOperationException("Vault not initialized yet.");
+        private set;
+    } = null!;
+    
+    /// <summary>
+    /// The manifest of the hosted vault.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if the manifest is accessed before initialization.</exception>
+    public RemoteVaultManifest Manifest
+    {
+        get => field ?? throw new InvalidOperationException("Manifest not initialized yet.");
+        set;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpVaultServerFixture"/> class.
+    /// </summary>
+    public HttpVaultServerFixture()
+    {
+        RootDirectory = new("Assets/TestVault");
+
+        // 5. Start Kestrel on free port
+        _port = GetFreeTcpPort();
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost
+            .UseKestrel()
+            .UseUrls($"http://127.0.0.1:{_port}");
+
+        _app = builder.Build();
+
+        _app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = new PhysicalFileProvider(RootDirectory.FullName),
+            ServeUnknownFileTypes = true
+        });
+    }
+
+    /// <summary>
+    /// Provides an HttpClient pointing to the vault root. Caller is responsible for disposing.
+    /// </summary>
+    public HttpClient CreateClient() => new() { BaseAddress = BaseUri };
+
+    /// <inheritdoc />
+    public async ValueTask InitializeAsync()
+    {
+        Manifest = await BuildManifestAsync(RootDirectory);
+        string manifestPath = Path.Combine(RootDirectory.FullName, RemoteVaultManifest.ManifestFileName);
+        await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(Manifest));
+        
+        await _app.StartAsync();
+        
+        Client = CreateClient();
+        Vault = HttpRemoteVault.FromManifest(Manifest, Client);
+    }
+    
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Creates a vault instance talking to the live HTTP server. Handy if a test wants direct IVault.
+    /// </summary>
+    public async Task<IVault> CreateHttpRemoteVaultAsync(CancellationToken ct = default)
+    {
+        HttpClient client = CreateClient();
+        RemoteVaultManifest m = await client.GetFromJsonAsync<RemoteVaultManifest>(RemoteVaultManifest.ManifestFileName, ct)
+            ?? throw new InvalidOperationException("Manifest could not be retrieved.");
+        return HttpRemoteVault.FromManifest(m, client);
+    }
+
+    private static async ValueTask<RemoteVaultManifest> BuildManifestAsync(DirectoryInfo root)
+    {
+        FileSystemVault fileVault = FileSystemVault.FromDirectory(root);
+        return await VaultManifestGenerator.GenerateManifestAsync(fileVault);
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        using TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpVaultServerFixtureCollection.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpVaultServerFixtureCollection.cs
@@ -1,0 +1,13 @@
+using Nodsoft.MoltenObsidian.Vaults.Http;
+
+namespace Nodsoft.MoltenObsidian.Tests.Vaults.Http;
+
+/// <summary>
+/// Provides a test fixture for the <see cref="FileSystemVault"/> class.
+/// </summary>
+[CollectionDefinition(nameof(HttpRemoteVault))]
+public abstract class HttpVaultServerFixtureCollection : ICollectionFixture<HttpVaultServerFixture>
+{
+	// This class has no code, and is never created.
+	// Its purpose is simply to be the place to apply [CollectionDefinition] and all the ICollectionFixture<> interfaces.
+}

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpVaultServerFixtureCollection.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/Http/HttpVaultServerFixtureCollection.cs
@@ -3,7 +3,7 @@ using Nodsoft.MoltenObsidian.Vaults.Http;
 namespace Nodsoft.MoltenObsidian.Tests.Vaults.Http;
 
 /// <summary>
-/// Provides a test fixture for the <see cref="FileSystemVault"/> class.
+/// Provides a test fixture for the <see cref="HttpRemoteVault" /> class.
 /// </summary>
 [CollectionDefinition(nameof(HttpRemoteVault))]
 public abstract class HttpVaultServerFixtureCollection : ICollectionFixture<HttpVaultServerFixture>

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultFixture.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultFixture.cs
@@ -1,4 +1,4 @@
-using Nodsoft.MoltenObsidian.Vaults.FileSystem;
+using JetBrains.Annotations;
 using Nodsoft.MoltenObsidian.Vaults.InMemory;
 
 namespace Nodsoft.MoltenObsidian.Tests.Vaults.InMemory;
@@ -7,6 +7,7 @@ namespace Nodsoft.MoltenObsidian.Tests.Vaults.InMemory;
 /// Provides a test fixture for the <see cref="InMemoryVault"/> class.
 /// </summary>
 
+[UsedImplicitly]
 public sealed class InMemoryVaultFixture : IDisposable
 {
     /// <summary>

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultFixtureCollection.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultFixtureCollection.cs
@@ -1,4 +1,3 @@
-using Nodsoft.MoltenObsidian.Vaults.FileSystem;
 using Nodsoft.MoltenObsidian.Vaults.InMemory;
 
 namespace Nodsoft.MoltenObsidian.Tests.Vaults.InMemory;

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultTests.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultTests.cs
@@ -1,8 +1,5 @@
 using System.Text;
-using Nodsoft.MoltenObsidian.Tests.Vaults.FileSystem;
 using Nodsoft.MoltenObsidian.Vault;
-using Nodsoft.MoltenObsidian.Vaults.FileSystem;
-using Nodsoft.MoltenObsidian.Vaults.FileSystem.Data;
 using Nodsoft.MoltenObsidian.Vaults.InMemory;
 using Nodsoft.MoltenObsidian.Vaults.InMemory.Data;
 
@@ -144,7 +141,7 @@ public sealed class InMemoryVaultTests
     // }
     
     /// <summary>
-    /// Tests the correct typing of a markdown file as a note.
+    /// Tests the correct typing of a Markdown file as a note.
     /// </summary>
     [Theory]
     [InlineData("mynote.md")]
@@ -178,7 +175,7 @@ public sealed class InMemoryVaultTests
         
         // Act
         IVaultNote note = vault.Notes["VeryNiceFolder/Hidden Note.md"];
-        string content = await note.ReadDocumentAsync();
+        string content = await note.ReadDocumentAsync(TestContext.Current.CancellationToken);
         
         // Assert
         Assert.NotNull(note);
@@ -214,7 +211,7 @@ public sealed class InMemoryVaultTests
         
         // Act
         IVaultNote note = vault.Notes["README.md"];
-        ObsidianText content = await note.ReadDocumentAsync();
+        ObsidianText content = await note.ReadDocumentAsync(TestContext.Current.CancellationToken);
         
         // Assert
         Assert.NotNull(note);

--- a/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultTests.cs
+++ b/Nodsoft.MoltenObsidian.Tests/Vaults/InMemory/InMemoryVaultTests.cs
@@ -251,7 +251,7 @@ public sealed class InMemoryVaultTests
     /// Tests that a file in a subfolder is not added twice to the parent folder's Files collection.
     /// </summary>
     [Fact]
-    public async Task CreateFile_InSubfolder_FileNotAddedTwice_Nominal()
+    public async Task CreateFile_InSubfolderFileNotAddedTwice_Nominal()
     {
         // Arrange
         InMemoryVault vault = _fixture.Vault;
@@ -270,5 +270,26 @@ public sealed class InMemoryVaultTests
         // Cleanup
         await vault.DeleteFileAsync(filePath);
         await vault.DeleteFolderAsync("SubFolder");
+    }
+    
+    /// <summary>
+    /// Tests the error handling when creating folders on invalid paths
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("/")]
+    public async Task CreateFolder_InvalidPath_ThrowsArgumentException(string path)
+    {
+        // Arrange
+        InMemoryVault vault = _fixture.Vault;
+        
+        // Act
+        // ReSharper disable once ConvertToLocalFunction
+        Func<Task<IVaultFolder>> action = async () => await vault.CreateFolderAsync(path!);
+        
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(action);
     }
 }

--- a/Nodsoft.MoltenObsidian.Tool/Commands/Manifest/GenerateManifestCommand.cs
+++ b/Nodsoft.MoltenObsidian.Tool/Commands/Manifest/GenerateManifestCommand.cs
@@ -71,7 +71,7 @@ public sealed class GenerateManifestSettings : CommandSettings
 [UsedImplicitly]
 public sealed class GenerateManifestCommand : AsyncCommand<GenerateManifestSettings>
 {
-	public override async Task<int> ExecuteAsync(CommandContext context, GenerateManifestSettings settings, CancellationToken ct)
+	protected override async Task<int> ExecuteAsync(CommandContext context, GenerateManifestSettings settings, CancellationToken ct)
 	{
 		if (settings.DebugMode)
 		{

--- a/Nodsoft.MoltenObsidian.Tool/Commands/SSG/GenerateStaticSiteCommand.cs
+++ b/Nodsoft.MoltenObsidian.Tool/Commands/SSG/GenerateStaticSiteCommand.cs
@@ -101,7 +101,7 @@ public sealed class GenerateStaticSiteCommandSettings : CommandSettings
 [UsedImplicitly]
 public sealed class GenerateStaticSite : AsyncCommand<GenerateStaticSiteCommandSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, GenerateStaticSiteCommandSettings settings, CancellationToken ct)
+    protected override async Task<int> ExecuteAsync(CommandContext context, GenerateStaticSiteCommandSettings settings, CancellationToken ct)
 	{
 		IVault vault = await StaticSiteGenerator.CreateReadVaultAsync(settings);
 		

--- a/Nodsoft.MoltenObsidian.Tool/Nodsoft.MoltenObsidian.Tool.csproj
+++ b/Nodsoft.MoltenObsidian.Tool/Nodsoft.MoltenObsidian.Tool.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Spectre.Console.Cli" Version="0.53.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
 		<PackageReference Include="Throw" Version="1.4.0" />
 	</ItemGroup>
 

--- a/Nodsoft.MoltenObsidian.slnx
+++ b/Nodsoft.MoltenObsidian.slnx
@@ -1,6 +1,7 @@
 ﻿<Solution>
 	<Project Path="Nodsoft.MoltenObsidian.Blazor\Nodsoft.MoltenObsidian.Blazor.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian.Manifest\Nodsoft.MoltenObsidian.Manifest.csproj" />
+	<Project Path="Nodsoft.MoltenObsidian.Blazor.Tests\Nodsoft.MoltenObsidian.Blazor.Tests.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian.Tests\Nodsoft.MoltenObsidian.Tests.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian.Tool\Nodsoft.MoltenObsidian.Tool.csproj" />
 	<Project Path="Nodsoft.MoltenObsidian\Nodsoft.MoltenObsidian.csproj" />

--- a/Nodsoft.MoltenObsidian/Nodsoft.MoltenObsidian.csproj
+++ b/Nodsoft.MoltenObsidian/Nodsoft.MoltenObsidian.csproj
@@ -5,8 +5,8 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
-		<PackageReference Include="Markdig" Version="0.43.0" />
+		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+		<PackageReference Include="Markdig" Version="1.1.2" />
 		<PackageReference Include="Nodsoft.Markdig.SyntaxHighlighting" Version="1.0.12" />
 		<PackageReference Include="YamlDotNet" Version="16.3.0" />
 	</ItemGroup>

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/Data/FileSystemVaultNote.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/Data/FileSystemVaultNote.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Nodsoft.MoltenObsidian.Vault;
+﻿using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Vaults.FileSystem.Data;
 

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/FileSystemVault.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/FileSystemVault.cs
@@ -287,18 +287,9 @@ public sealed class FileSystemVault : IWritableVault
 	/// <inheritdoc />
 	public ValueTask<IVaultFolder> CreateFolderAsync(string path)
 	{
-		// Small starters : Strip the leading slash if present
-		if (path.StartsWith('/'))
-		{
-			path = path[1..];
-		}
+		// First checks : Strip leading slashes and make sure the path is valid
+		path = NormalizePath(path);
 		
-		// First checks : Is this a valid path?
-		if (path is null or "" or "/")
-		{
-			throw new ArgumentException("The specified path is invalid.", nameof(path));
-		}
-
 		// Second checks : Does the folder already exist?
 		if (Folders.TryGetValue(path, out IVaultFolder? existing))
 		{
@@ -339,17 +330,8 @@ public sealed class FileSystemVault : IWritableVault
 	/// <inheritdoc />
 	public async ValueTask<IVaultFile> WriteFileAsync(string path, Stream content)
 	{
-		// Small step: Strip the leading slash if present
-		if (path.StartsWith('/'))
-		{
-			path = path[1..];
-		}
-		
-		// First checks : Is this a valid path?
-		if (path is null or "")
-		{
-			throw new ArgumentException("The specified path is invalid.", nameof(path));
-		}
+		// First checks : Strip leading slashes and make sure the path is valid
+		path = NormalizePath(path);
 		
 		// Does the parent folder exist? If not, create it.
 		// Luckily, we can use the CreateFolderAsync method for this.
@@ -382,17 +364,8 @@ public sealed class FileSystemVault : IWritableVault
 	/// <inheritdoc />
 	public async ValueTask DeleteFolderAsync(string path)
 	{
-		// Small step: Strip the leading slash if present
-		if (path.StartsWith('/'))
-		{
-			path = path[1..];
-		}
-		
-		// First checks : Is this a valid path?
-		if (path is null or "")
-		{
-			throw new ArgumentException("The specified path is invalid.", nameof(path));
-		}
+		// First checks : Strip leading slashes and make sure the path is valid
+		path = NormalizePath(path);
 
 		// Second checks : Does the folder exist?
 		if (!_folders.TryRemove(path, out IVaultFolder? folder))
@@ -426,17 +399,8 @@ public sealed class FileSystemVault : IWritableVault
 	/// <inheritdoc />
 	public async ValueTask DeleteFileAsync(string path)
 	{
-		// Small step: Strip the leading slash if present
-		if (path.StartsWith('/'))
-		{
-			path = path[1..];
-		}
-		
-		// First checks : Is this a valid path?
-		if (path is null or "")
-		{
-			throw new ArgumentException("The specified path is invalid.", nameof(path));
-		}
+		// First checks : Strip leading slashes and make sure the path is valid
+		path = NormalizePath(path);
 
 		// Second checks : Does the file exist?
 		if (!_files.TryRemove(path, out IVaultFile? file))
@@ -466,5 +430,31 @@ public sealed class FileSystemVault : IWritableVault
 		}
 		
 		return DeleteFileAsync(path);
+	}
+	
+	/// <summary>
+	/// Strips the leading slash from a path if present, and ensures it is valid.
+	/// </summary>
+	/// <returns>The normalized path.</returns>
+	/// <exception cref="ArgumentException">Thrown if the path is null, empty or invalid.</exception>
+	[Pure]
+	private static string NormalizePath(string? path)
+	{
+		if (path is not null)
+		{
+			// Strip the leading slash if present
+			if (path.StartsWith('/'))
+			{
+				path = path[1..];
+			}
+		}
+
+		// Is this a valid path?
+		if (string.IsNullOrWhiteSpace(path))
+		{
+			throw new ArgumentException("The specified path is invalid.", nameof(path));
+		}
+
+		return path;
 	}
 }

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/FileSystemVault.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/FileSystemVault.cs
@@ -71,7 +71,7 @@ public sealed class FileSystemVault : IWritableVault
 	/// <summary>
 	/// Gets the default list of files to ignore when loading a vault.
 	/// </summary>
-	public static IEnumerable<string> DefaultIgnoredFiles { get; } = [".DS_Store"];
+	public static IEnumerable<string> DefaultIgnoredFiles { get; } = [".DS_Store", "moltenobsidian.manifest.json"];
 
 	/// <summary>
 	/// Creates a new <see cref="FileSystemVault"/> instance from the specified path.

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/VaultDependencyInjectionExtensions.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.FileSystem/VaultDependencyInjectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.Versioning;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Nodsoft.MoltenObsidian.Vault;
 using Nodsoft.MoltenObsidian.Vaults.FileSystem;
 

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Data/FtpRemoteNote.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Data/FtpRemoteNote.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Nodsoft.MoltenObsidian.Manifest;
+﻿using Nodsoft.MoltenObsidian.Manifest;
 using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Vaults.Ftp.Data;

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Nodsoft.MoltenObsidian.Vaults.Ftp.csproj
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Nodsoft.MoltenObsidian.Vaults.Ftp.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Nodsoft.MoltenObsidian.Manifest\Nodsoft.MoltenObsidian.Manifest.csproj" />
 
-        <PackageReference Include="FluentFTP" Version="53.0.2" />
+        <PackageReference Include="FluentFTP" Version="54.1.0" />
     </ItemGroup>
     
 </Project>

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Utils.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.Ftp/Utils.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using FluentFTP;
+﻿using FluentFTP;
 
 namespace Nodsoft.MoltenObsidian.Vaults.Ftp;
 

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.Http/Data/HttpRemoteNote.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.Http/Data/HttpRemoteNote.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Nodsoft.MoltenObsidian.Manifest;
+﻿using Nodsoft.MoltenObsidian.Manifest;
 using Nodsoft.MoltenObsidian.Vault;
 
 namespace Nodsoft.MoltenObsidian.Vaults.Http.Data;

--- a/Vaults/Nodsoft.MoltenObsidian.Vaults.InMemory/InMemoryVault.cs
+++ b/Vaults/Nodsoft.MoltenObsidian.Vaults.InMemory/InMemoryVault.cs
@@ -8,6 +8,7 @@ namespace Nodsoft.MoltenObsidian.Vaults.InMemory;
 /// <summary>
 /// Represents an in-memory vault.
 /// </summary>
+[PublicAPI]
 public sealed class InMemoryVault : IWritableVault
 {
     private readonly ConcurrentDictionary<string, IVaultFolder> _folders = [];
@@ -56,17 +57,8 @@ public sealed class InMemoryVault : IWritableVault
     /// <inheritdoc />
     public async ValueTask<IVaultFolder> CreateFolderAsync(string path)
     {
-        // Small starters : Strip the leading slash if present
-        if (path.StartsWith('/'))
-        {
-            path = path[1..];
-        }
-		
-        // First checks : Is this a valid path?
-        if (path is null or "" or "/")
-        {
-            throw new ArgumentException("The specified path is invalid.", nameof(path));
-        }
+        // First checks : Strip leading slashes and make sure the path is valid
+        path = NormalizePath(path);
 
         // Second checks : Does the folder already exist?
         if (Folders.TryGetValue(path, out IVaultFolder? existing))
@@ -114,17 +106,8 @@ public sealed class InMemoryVault : IWritableVault
     /// <inheritdoc />
     public async ValueTask DeleteFolderAsync(string path)
     {
-        // Small step: Strip the leading slash if present
-        if (path.StartsWith('/'))
-        {
-            path = path[1..];
-        }
-
-        // First checks : Is this a valid path?
-        if (path is null or "")
-        {
-            throw new ArgumentException("The specified path is invalid.", nameof(path));
-        }
+        // First checks : Strip leading slashes and make sure the path is valid
+        path = NormalizePath(path);
 
         // Second checks : Does the folder exist?
         if (!_folders.TryRemove(path, out IVaultFolder? folder))
@@ -164,17 +147,8 @@ public sealed class InMemoryVault : IWritableVault
     /// <inheritdoc />
     public async ValueTask<IVaultFile> WriteFileAsync(string path, Stream content)
     {
-        // Small step: Strip the leading slash if present
-        if (path.StartsWith('/'))
-        {
-            path = path[1..];
-        }
-		
-        // First checks : Is this a valid path?
-        if (path is null or "")
-        {
-            throw new ArgumentException("The specified path is invalid.", nameof(path));
-        }
+        // First checks : Strip leading slashes and make sure the path is valid
+        path = NormalizePath(path);
         
         // Does the parent folder exist? If not, create it.
         // Luckily, we can use the CreateFolderAsync method for this.
@@ -201,18 +175,9 @@ public sealed class InMemoryVault : IWritableVault
     /// <inheritdoc />
     public async ValueTask DeleteFileAsync(string path)
     {
-        // Small step: Strip the leading slash if present
-        if (path.StartsWith('/'))
-        {
-            path = path[1..];
-        }
-		
-        // First checks : Is this a valid path?
-        if (path is null or "")
-        {
-            throw new ArgumentException("The specified path is invalid.", nameof(path));
-        }
-
+        // First checks : Strip leading slashes and make sure the path is valid
+        path = NormalizePath(path);
+        
         // Second checks : Does the file exist?
         if (!_files.TryRemove(path, out IVaultFile? file))
         {
@@ -257,5 +222,31 @@ public sealed class InMemoryVault : IWritableVault
         }
 		
         await DeleteFileAsync(path);
+    }
+
+    /// <summary>
+    /// Strips the leading slash from a path if present, and ensures it is valid.
+    /// </summary>
+    /// <returns>The normalized path.</returns>
+    /// <exception cref="ArgumentException">Thrown if the path is null, empty or invalid.</exception>
+    [Pure]
+    private static string NormalizePath(string? path)
+    {
+        if (path is not null)
+        {
+            // Strip the leading slash if present
+            if (path.StartsWith('/'))
+            {
+                path = path[1..];
+            }
+        }
+
+        // Is this a valid path?
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("The specified path is invalid.", nameof(path));
+        }
+
+        return path;
     }
 }


### PR DESCRIPTION
## Highlights
- Add comprehensive tests
  - Introduce a Blazor test project with bUnit-based coverage for navigation and display components, helpers, services, and DI wiring
  - Add an HTTP remote vault test fixture powered by a lightweight Kestrel host and cover HTTP-backed scenarios
  - Tighten existing tests (cancellation tokens, sealed classes, minor assertions) and wire the new project into the solution

- Fix navigation behavior
  - Correct index note detection in folders (properly matches README.md/index.md)
  - Treat “false” frontmatter values (including string variants) as disabling index notes

- Refactor for robustness
  - Centralize path normalization/validation across in‑memory and file system vaults
  - Ignore the generated manifest file by default in file system vault enumeration
  - Add cancellation token support to manifest generation and hashing operations

- Update dependencies
  - Bump UI, runtime, and tooling packages (e.g., ASP.NET Components.Web, System.Text.Json, Spectre.Console.Cli, Markdig, FluentFTP, test SDKs, reproducible builds plugin)
  - Adjust command overrides to align with updated CLI APIs

## Breaking Changes
- None expected. Manifest APIs accept an optional cancellation token and remain source-compatible. Path validation becomes stricter but aligns with existing behavior and prevents invalid inputs earlier.